### PR TITLE
Add peer-to-peer messaging with multi-transport support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -233,7 +233,8 @@
       "Bash(-e 's/contact: The contact/peer: The peer/g' )",
       "Bash(-e 's/contact\\./peer./g' )",
       "Bash(-e 's/Contact object/Peer object/g' )",
-      "Bash(-e 's/ contact,/ peer,/g' )"
+      "Bash(-e 's/ contact,/ peer,/g' )",
+      "Bash(true)"
     ],
     "deny": []
   }

--- a/syft_client/platforms/google_org/gdrive_files.py
+++ b/syft_client/platforms/google_org/gdrive_files.py
@@ -40,6 +40,7 @@ class GDriveFilesTransport(BaseTransportLayer, BaseTransport):
         self._setup_verified = False
         self._contacts_folder_id = None
         self._syftbox_folder_id = None
+        self.verbose = True  # Default verbose mode
     
     @staticmethod
     def check_api_enabled(platform_client: Any) -> bool:

--- a/syft_client/platforms/google_personal/gdrive_files.py
+++ b/syft_client/platforms/google_personal/gdrive_files.py
@@ -40,6 +40,7 @@ class GDriveFilesTransport(BaseTransportLayer, BaseTransport):
         self._setup_verified = False
         self._contacts_folder_id = None
         self._syftbox_folder_id = None
+        self.verbose = True  # Default verbose mode
     
     @staticmethod
     def check_api_enabled(platform_client: Any) -> bool:

--- a/syft_client/platforms/google_personal/gsheets.py
+++ b/syft_client/platforms/google_personal/gsheets.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import json
 import pickle
 from datetime import datetime
+from pathlib import Path
 
 from googleapiclient.discovery import build
 from ..transport_base import BaseTransportLayer
@@ -1064,7 +1065,7 @@ class GSheetsTransport(BaseTransportLayer, BaseTransport):
         return PeerResource(
             peer_email=email,
             transport_name=self.transport_name,
-            platform_name=getattr(self._platform_client, 'platform', 'google_personal') if hasattr(self, '_platform_client') else 'google_personal',
+            platform_name=getattr(self._platform_client, 'platform', 'google_org') if hasattr(self, '_platform_client') else 'google_org',
             resource_type='message_sheets',
             available=bool(outgoing_sheet or incoming_sheet),
             # Map to folder structure for consistent display
@@ -1094,7 +1095,7 @@ class GSheetsTransport(BaseTransportLayer, BaseTransport):
             # Search for shared message sheets
             query = f"sharedWithMe=true and name contains 'syft_' and name contains '_messages' and mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
             
-            results = self.sheets_service.files().list(
+            results = self.drive_service.files().list(
                 q=query,
                 fields="files(id, name, owners)",
                 pageSize=1000
@@ -1127,3 +1128,263 @@ class GSheetsTransport(BaseTransportLayer, BaseTransport):
         except Exception as e:
             # Silently fail - peer request checking is optional
             return []
+    
+    def check_inbox(self, sender_email: str, download_dir: Optional[str] = None, verbose: bool = True) -> List[Dict]:
+        """
+        Check for incoming messages from a specific sender in Google Sheets
+        
+        Args:
+            sender_email: Email of the sender to check messages from
+            download_dir: Directory to download messages to (defaults to SyftBox directory)
+            verbose: Whether to print progress
+            
+        Returns:
+            List of message info dicts with keys: id, timestamp, size, data, extracted_to
+        """
+        if not self.is_setup():
+            return []
+        
+        downloaded_messages = []
+        
+        try:
+            # Determine the message sheet name pattern
+            my_email = self.email
+            
+            # Try both naming patterns
+            sheet_names = [
+                # New pattern with @ and . 
+                f"syft_{sender_email}_to_{my_email}_outbox_inbox",
+                # Legacy pattern with underscores and _messages suffix
+                f"syft_{sender_email.replace('@', '_at_').replace('.', '_')}_to_{my_email.replace('@', '_at_').replace('.', '_')}_messages"
+            ]
+            
+            sheet = None
+            sheet_id = None
+            
+            # Try each pattern
+            for sheet_name in sheet_names:
+                query = f"name='{sheet_name}' and mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
+                results = self.drive_service.files().list(
+                    q=query,
+                    fields="files(id, name, webViewLink)",
+                    pageSize=10
+                ).execute()
+                
+                sheets = results.get('files', [])
+                if sheets:
+                    sheet = sheets[0]
+                    sheet_id = sheet['id']
+                    if verbose:
+                        print(f"   Found message sheet: {sheet['name']}")
+                    break
+            
+            if not sheet:
+                if verbose:
+                    print(f"   No message sheet found for patterns: {sheet_names}")
+                return []
+            
+            # Read messages from the sheet
+            result = self.sheets_service.spreadsheets().values().get(
+                spreadsheetId=sheet_id,
+                range="messages!A:D"
+            ).execute()
+            
+            values = result.get('values', [])
+            
+            if not values:
+                return []
+            
+            # Skip header if present
+            if values and values[0] == ['timestamp', 'message_id', 'size', 'data']:
+                values = values[1:]
+            
+            # Set up download directory
+            if download_dir is None:
+                # Use SyftBox directory
+                if hasattr(self._platform_client, '_client') and self._platform_client._client:
+                    client = self._platform_client._client
+                    if hasattr(client, 'local_syftbox_dir') and client.local_syftbox_dir:
+                        download_dir = str(client.local_syftbox_dir)
+                    else:
+                        download_dir = str(Path.home() / f"SyftBox_{my_email}")
+                else:
+                    download_dir = str(Path.home() / f"SyftBox_{my_email}")
+            
+            download_path = Path(download_dir)
+            download_path.mkdir(parents=True, exist_ok=True)
+            
+            # Process each message
+            messages_to_archive = []
+            
+            for row in values:
+                if len(row) >= 4:
+                    timestamp, message_id, size_str, data = row
+                    
+                    try:
+                        # Decode the base64 data
+                        import base64
+                        message_data = base64.b64decode(data)
+                        
+                        # Save to temporary file
+                        temp_file = download_path / f"{message_id}.tar.gz"
+                        with open(temp_file, 'wb') as f:
+                            f.write(message_data)
+                        
+                        # Extract the archive
+                        import tarfile
+                        with tarfile.open(temp_file, 'r:gz') as tar:
+                            # Extract to the download directory
+                            tar.extractall(download_path)
+                        
+                        # Find the extracted message directory
+                        extracted_dir = download_path / message_id
+                        
+                        # Read metadata if available
+                        metadata = {}
+                        metadata_file = extracted_dir / f"{message_id}.json"
+                        if metadata_file.exists():
+                            import json
+                            with open(metadata_file, 'r') as f:
+                                metadata = json.load(f)
+                        
+                        # Process the data files to their final destination
+                        data_dir = extracted_dir / "data"
+                        if data_dir.exists():
+                            # Move files from data dir to their proper location
+                            import shutil
+                            for item in data_dir.iterdir():
+                                # Determine destination based on metadata
+                                if 'original_path' in metadata:
+                                    # Use original path from metadata
+                                    dest = download_path / metadata['original_path'] / item.name
+                                else:
+                                    # Default to root of download dir
+                                    dest = download_path / item.name
+                                
+                                # Create parent directories
+                                dest.parent.mkdir(parents=True, exist_ok=True)
+                                
+                                # Move the file/directory
+                                if item.is_dir():
+                                    if dest.exists():
+                                        shutil.rmtree(dest)
+                                    shutil.move(str(item), str(dest))
+                                else:
+                                    shutil.move(str(item), str(dest))
+                                
+                                if verbose:
+                                    print(f"   📥 Extracted: {dest.name}")
+                        
+                        # Clean up temporary files
+                        temp_file.unlink()
+                        if extracted_dir.exists():
+                            import shutil
+                            shutil.rmtree(extracted_dir)
+                        
+                        # Add to results
+                        downloaded_messages.append({
+                            'id': message_id,
+                            'timestamp': timestamp,
+                            'size': int(size_str) if size_str.isdigit() else 0,
+                            'metadata': metadata,
+                            'extracted_to': str(download_path)
+                        })
+                        
+                        # Mark for archiving
+                        messages_to_archive.append(row)
+                        
+                    except Exception as e:
+                        if verbose:
+                            print(f"   ❌ Error processing message {message_id}: {e}")
+            
+            # Archive processed messages
+            if messages_to_archive:
+                self._archive_messages(sheet_id, messages_to_archive, verbose)
+            
+            return downloaded_messages
+            
+        except Exception as e:
+            if verbose:
+                print(f"   ❌ Error checking inbox: {e}")
+            return []
+    
+    def _archive_messages(self, sheet_id: str, messages: List[List[str]], verbose: bool = True):
+        """Archive processed messages to the archive sheet"""
+        try:
+            # Check if archive sheet exists
+            spreadsheet = self.sheets_service.spreadsheets().get(
+                spreadsheetId=sheet_id
+            ).execute()
+            
+            sheets = {sheet['properties']['title']: sheet['properties']['sheetId'] 
+                     for sheet in spreadsheet.get('sheets', [])}
+            
+            if 'archive' not in sheets:
+                # Create archive sheet
+                requests = [{
+                    'addSheet': {
+                        'properties': {
+                            'title': 'archive',
+                            'gridProperties': {
+                                'columnCount': 4,
+                                'frozenRowCount': 0
+                            }
+                        }
+                    }
+                }]
+                
+                self.sheets_service.spreadsheets().batchUpdate(
+                    spreadsheetId=sheet_id,
+                    body={'requests': requests}
+                ).execute()
+                
+                # Add header
+                self.sheets_service.spreadsheets().values().update(
+                    spreadsheetId=sheet_id,
+                    range='archive!A1:D1',
+                    valueInputOption='RAW',
+                    body={'values': [['timestamp', 'message_id', 'size', 'data']]}
+                ).execute()
+            
+            # Append to archive
+            self.sheets_service.spreadsheets().values().append(
+                spreadsheetId=sheet_id,
+                range='archive!A:D',
+                valueInputOption='RAW',
+                body={'values': messages}
+            ).execute()
+            
+            # Remove from messages sheet
+            # Get current messages
+            result = self.sheets_service.spreadsheets().values().get(
+                spreadsheetId=sheet_id,
+                range="messages!A:D"
+            ).execute()
+            
+            current_values = result.get('values', [])
+            
+            # Filter out archived messages
+            message_ids = {row[1] for row in messages}  # message_id is in column 2
+            new_values = [row for row in current_values 
+                         if len(row) < 2 or row[1] not in message_ids]
+            
+            # Clear and rewrite messages sheet
+            self.sheets_service.spreadsheets().values().clear(
+                spreadsheetId=sheet_id,
+                range="messages!A:D"
+            ).execute()
+            
+            if new_values:
+                self.sheets_service.spreadsheets().values().update(
+                    spreadsheetId=sheet_id,
+                    range='messages!A:D',
+                    valueInputOption='RAW',
+                    body={'values': new_values}
+                ).execute()
+            
+            if verbose:
+                print(f"   📦 Archived {len(messages)} message{'s' if len(messages) != 1 else ''}")
+                
+        except Exception as e:
+            if verbose:
+                print(f"   ⚠️  Error archiving messages: {e}")

--- a/syft_client/syft_client.py
+++ b/syft_client/syft_client.py
@@ -392,7 +392,8 @@ class SyftClient:
         """
         return self.sync.send_to_peers(path)
     
-    def send_to(self, path: str, recipient: str, requested_latency_ms: Optional[int] = None, priority: str = "normal") -> bool:
+    def send_to(self, path: str, recipient: str, requested_latency_ms: Optional[int] = None, 
+                priority: str = "normal", transport: Optional[str] = None) -> bool:
         """
         Send file/folder to specific recipient
         
@@ -401,11 +402,13 @@ class SyftClient:
             recipient: Email address of recipient
             requested_latency_ms: Desired latency in milliseconds (optional)
             priority: "urgent", "normal", or "background" (default: "normal")
+            transport: Specific transport to use (e.g., "gdrive_files", "gsheets", "gmail"). 
+                      If None, automatically selects best transport.
             
         Returns:
             True if successful
         """
-        return self.sync.send_to(path, recipient, requested_latency_ms, priority)
+        return self.sync.send_to(path, recipient, requested_latency_ms, priority, transport)
     
     def add_peer(self, email: str) -> bool:
         """

--- a/syft_client/syft_client.py
+++ b/syft_client/syft_client.py
@@ -1231,8 +1231,8 @@ class SyftClient:
             
             # Step 9: Warm the cache
             current_step += 1
-            print_progress(current_step, "Warming the cache")
-            str_self = str(self)
+            print_progress(current_step, "Getting list of active transports")
+            
             
             # Final success message with peer count
             peer_count = 0

--- a/syft_client/sync/__init__.py
+++ b/syft_client/sync/__init__.py
@@ -60,9 +60,10 @@ class SyncManager:
         """Send file/folder to all peers"""
         return self.sender.send_to_peers(path)
     
-    def send_to(self, path: str, recipient: str, requested_latency_ms: Optional[int] = None, priority: str = "normal") -> bool:
+    def send_to(self, path: str, recipient: str, requested_latency_ms: Optional[int] = None, 
+                priority: str = "normal", transport: Optional[str] = None) -> bool:
         """Send file/folder to specific recipient"""
-        return self.sender.send_to(path, recipient, requested_latency_ms, priority)
+        return self.sender.send_to(path, recipient, requested_latency_ms, priority, transport)
     
     # Path resolution
     def resolve_path(self, path: str) -> str:

--- a/syft_client/sync/peer_model.py
+++ b/syft_client/sync/peer_model.py
@@ -571,13 +571,16 @@ class Peer:
         
         return output.strip()
     
-    def check_inbox(self, download_dir: Optional[str] = None, verbose: bool = True) -> Dict[str, List[Dict]]:
+    def check_inbox(self, download_dir: Optional[str] = None, verbose: bool = True, 
+                    transport: Optional[str] = None) -> Dict[str, List[Dict]]:
         """
         Check all transport layers for incoming messages from this peer
         
         Args:
             download_dir: Optional directory to download messages to. If None, uses SyftBox directory
             verbose: Whether to print progress
+            transport: Specific transport to check (e.g., "gdrive_files", "gsheets", "gmail").
+                      If None, checks all verified transports.
             
         Returns:
             Dictionary mapping transport names to list of downloaded messages
@@ -589,10 +592,27 @@ class Peer:
         total_messages = 0
         
         if verbose:
-            print(f"📬 Checking inbox for messages from {self.email}...")
+            if transport:
+                print(f"📬 Checking {transport} inbox for messages from {self.email}...")
+            else:
+                print(f"📬 Checking inbox for messages from {self.email}...")
         
-        # Check each verified transport
-        for transport_name in self.get_verified_transports():
+        # Determine which transports to check
+        if transport:
+            # Check specific transport only
+            if transport not in self.available_transports:
+                print(f"❌ Transport '{transport}' is not available for {self.email}")
+                print(f"   Available transports: {list(self.available_transports.keys())}")
+                return {}
+            if not self.available_transports[transport].verified:
+                print(f"⚠️  Transport '{transport}' is not verified for {self.email}")
+            transports_to_check = [transport]
+        else:
+            # Check all verified transports
+            transports_to_check = self.get_verified_transports()
+        
+        # Check each transport
+        for transport_name in transports_to_check:
             if verbose:
                 print(f"\n🔄 Checking {transport_name}...")
             

--- a/syft_client/sync/sender.py
+++ b/syft_client/sync/sender.py
@@ -113,7 +113,7 @@ class MessageSender:
         
         # Get peer object
         peer = self.peers.get_peer(recipient)
-        if not contact:
+        if not peer:
             print(f"❌ Could not load peer information for {recipient}")
             return False
         

--- a/test_notebooks/Test Sync.ipynb
+++ b/test_notebooks/Test Sync.ipynb
@@ -14,8 +14,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "15720272-4c29-48a6-a4b6-4efe825bc897",
+   "execution_count": 2,
+   "id": "0c1c4206-a57e-46a8-bc12-d25209cccfa4",
    "metadata": {},
    "outputs": [
     {
@@ -32,375 +32,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "f45d3740-1618-4013-b73b-4627a6e69867",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                                                                "
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭────── SyftClient.email = 'liamtrask@gmail.com' ───────╮\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.folder</span> = /Users/atrask/SyftBox_liamtrask@gmail.com  │\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.platforms</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(for peer-to-peer communication)</span>          │\n",
-       "│    <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">.google_personal</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                         │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gmail</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                             │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gdrive_files</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                      │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gsheets</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                           │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gforms</span>                                      │\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   │\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">.peers</span>  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 active, 0 pending)</span>                        │\n",
-       "│                                                       │\n",
-       "│    [0] andrew@openmined.org                           │\n",
-       "│    [1] stephen@openmined.org                          │\n",
-       "│    [2] rasswanth@openmined.org                        │\n",
-       "│                                                       │\n",
-       "╰───────────────────────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭────── SyftClient.email = 'liamtrask@gmail.com' ───────╮\n",
-       "│                                                       │\n",
-       "│  \u001b[2m.folder\u001b[0m = /Users/atrask/SyftBox_liamtrask@gmail.com  │\n",
-       "│                                                       │\n",
-       "│  \u001b[2m.platforms\u001b[0m \u001b[2m(for peer-to-peer communication)\u001b[0m          │\n",
-       "│    \u001b[1;33m.google_personal\u001b[0m \u001b[2m(3 peers)\u001b[0m                         │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gmail\u001b[0m \u001b[2m(3 peers)\u001b[0m                             │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gdrive_files\u001b[0m \u001b[2m(3 peers)\u001b[0m                      │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gsheets\u001b[0m \u001b[2m(3 peers)\u001b[0m                           │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gforms\u001b[0m                                      │\n",
-       "│                                                       │\n",
-       "│  \u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m   │\n",
-       "│                                                       │\n",
-       "│  \u001b[1;36m.peers\u001b[0m  \u001b[2m(3 active, 0 pending)\u001b[0m                        │\n",
-       "│                                                       │\n",
-       "│    [0] andrew@openmined.org                           │\n",
-       "│    [1] stephen@openmined.org                          │\n",
-       "│    [2] rasswanth@openmined.org                        │\n",
-       "│                                                       │\n",
-       "╰───────────────────────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "a4e3aa98-e6ae-4154-9ad4-9d6f0595a0fa",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🔄 Adding stephen@openmined.org on google_personal.gdrive_files...\n",
-      "   ✅ Added on google_personal.gdrive_files\n",
-      "🔄 Adding stephen@openmined.org on google_personal.gmail...\n",
-      "   ✅ Added on google_personal.gmail\n",
-      "🔄 Adding stephen@openmined.org on google_personal.gsheets...\n",
-      "   ✅ Added on google_personal.gsheets\n",
-      "\n",
-      "✅ Peer stephen@openmined.org added successfully on 3 transport(s)\n",
-      "   • google_personal.gdrive_files\n",
-      "   • google_personal.gmail\n",
-      "   • google_personal.gsheets\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client1.add_peer(\"stephen@openmined.org\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "eb7e460e-20e8-44f3-82e3-151ad391e00b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭──────────── Peer: rasswanth ─────────────╮\n",
-       "│                                          │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">Email:</span> rasswanth@openmined.org          │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">Platform:</span> google_personal               │\n",
-       "│                                          │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Added: 2025-09-26 22:26</span>                 │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Capabilities updated: 2025-09-26 22:26</span>  │\n",
-       "│                                          │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.platforms</span>                              │\n",
-       "│    <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">.google_personal</span>                      │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008080; text-decoration-color: #008080\">.gdrive_files</span>                     │\n",
-       "│         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">verified 0 minutes ago</span>           │\n",
-       "│      <span style=\"color: #800000; text-decoration-color: #800000\">✗</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.gforms</span>                           │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008080; text-decoration-color: #008080\">.gmail</span>                            │\n",
-       "│         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">verified 0 minutes ago</span>           │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008080; text-decoration-color: #008080\">.gsheets</span>                          │\n",
-       "│         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">verified 0 minutes ago</span>           │\n",
-       "│                                          │\n",
-       "╰──────────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭──────────── Peer: rasswanth ─────────────╮\n",
-       "│                                          │\n",
-       "│  \u001b[1;36mEmail:\u001b[0m rasswanth@openmined.org          │\n",
-       "│  \u001b[1;36mPlatform:\u001b[0m google_personal               │\n",
-       "│                                          │\n",
-       "│  \u001b[2mAdded: 2025-09-26 22:26\u001b[0m                 │\n",
-       "│  \u001b[2mCapabilities updated: 2025-09-26 22:26\u001b[0m  │\n",
-       "│                                          │\n",
-       "│  \u001b[2m.platforms\u001b[0m                              │\n",
-       "│    \u001b[1;33m.google_personal\u001b[0m                      │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[36m.gdrive_files\u001b[0m                     │\n",
-       "│         \u001b[2mverified 0 minutes ago\u001b[0m           │\n",
-       "│      \u001b[31m✗\u001b[0m \u001b[2m.gforms\u001b[0m                           │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[36m.gmail\u001b[0m                            │\n",
-       "│         \u001b[2mverified 0 minutes ago\u001b[0m           │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[36m.gsheets\u001b[0m                          │\n",
-       "│         \u001b[2mverified 0 minutes ago\u001b[0m           │\n",
-       "│                                          │\n",
-       "╰──────────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "rass = client1.peers[1]\n",
-    "rass"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "1812ee5b-fcec-4a8c-9162-456d30f61a06",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭─────────────────────────── Gsheets Resources ───────────────────────────╮\n",
-       "│                                                                         │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">Peer:</span> rasswanth@openmined.org                                          │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">Transport:</span> google_personal.gsheets                                     │\n",
-       "│                                                                         │\n",
-       "│  <span style=\"font-weight: bold\">Communication Folders:</span>                                                 │\n",
-       "│                                                                         │\n",
-       "│  <span style=\"color: #008000; text-decoration-color: #008000\">📤 Outbox/Inbox (Shared):</span>                                              │\n",
-       "│     <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">syft_liamtrask_at_gmail_com_to_rasswanth_at_openmined_org_messages</span>  │\n",
-       "│     <a href=\"https://docs.google.com/spreadsheets/d/1osExv--26RR-NEBkosEwiHCjU4ZUhZlGEKAS4cJReUE\" target=\"_blank\">→ Open in Drive</a>                                                     │\n",
-       "│                                                                         │\n",
-       "╰─────────────────────────────────────────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭─────────────────────────── Gsheets Resources ───────────────────────────╮\n",
-       "│                                                                         │\n",
-       "│  \u001b[1;36mPeer:\u001b[0m rasswanth@openmined.org                                          │\n",
-       "│  \u001b[1;36mTransport:\u001b[0m google_personal.gsheets                                     │\n",
-       "│                                                                         │\n",
-       "│  \u001b[1mCommunication Folders:\u001b[0m                                                 │\n",
-       "│                                                                         │\n",
-       "│  \u001b[32m📤 Outbox/Inbox (Shared):\u001b[0m                                              │\n",
-       "│     \u001b[2msyft_liamtrask_at_gmail_com_to_rasswanth_at_openmined_org_messages\u001b[0m  │\n",
-       "│     \u001b]8;id=493370;https://docs.google.com/spreadsheets/d/1osExv--26RR-NEBkosEwiHCjU4ZUhZlGEKAS4cJReUE\u001b\\→ Open in Drive\u001b]8;;\u001b\\                                                     │\n",
-       "│                                                                         │\n",
-       "╰─────────────────────────────────────────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "rass.platforms.google_personal.gsheets"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5cc66349-175b-4294-89c4-deffc9133288",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e781b6d2-88db-4be6-be8e-a3ad9dc84bb7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23fc0e4b-aec3-4f9f-97f6-2280b39e5c1c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b87ac377-9a60-45f2-a791-b37a22994f4d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4bb0c144-874a-463d-891b-2b72935290f1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65063a9c-40a9-4ee4-9f8d-ece7e46baea8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dd81f06a-1731-4f70-9967-d628bb866c9d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "5bb2ba8e-da14-404b-9e97-cc892072f571",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                                                                "
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭────── SyftClient.email = 'liamtrask@gmail.com' ───────╮\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.folder</span> = /Users/atrask/SyftBox_liamtrask@gmail.com  │\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.platforms</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(for peer-to-peer communication)</span>          │\n",
-       "│    <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">.google_personal</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(1 peer)</span>                          │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gmail</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(1 peer)</span>                              │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gdrive_files</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(1 peer)</span>                       │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gsheets</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(1 peer)</span>                            │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gforms</span>                                      │\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   │\n",
-       "│                                                       │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">.peers</span>  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(1 active, 0 pending)</span>                        │\n",
-       "│                                                       │\n",
-       "│    [0] andrew@openmined.org                           │\n",
-       "│                                                       │\n",
-       "╰───────────────────────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭────── SyftClient.email = 'liamtrask@gmail.com' ───────╮\n",
-       "│                                                       │\n",
-       "│  \u001b[2m.folder\u001b[0m = /Users/atrask/SyftBox_liamtrask@gmail.com  │\n",
-       "│                                                       │\n",
-       "│  \u001b[2m.platforms\u001b[0m \u001b[2m(for peer-to-peer communication)\u001b[0m          │\n",
-       "│    \u001b[1;33m.google_personal\u001b[0m \u001b[2m(1 peer)\u001b[0m                          │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gmail\u001b[0m \u001b[2m(1 peer)\u001b[0m                              │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gdrive_files\u001b[0m \u001b[2m(1 peer)\u001b[0m                       │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gsheets\u001b[0m \u001b[2m(1 peer)\u001b[0m                            │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gforms\u001b[0m                                      │\n",
-       "│                                                       │\n",
-       "│  \u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m   │\n",
-       "│                                                       │\n",
-       "│  \u001b[1;36m.peers\u001b[0m  \u001b[2m(1 active, 0 pending)\u001b[0m                        │\n",
-       "│                                                       │\n",
-       "│    [0] andrew@openmined.org                           │\n",
-       "│                                                       │\n",
-       "╰───────────────────────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "4f06b90b-5f69-4b15-bedb-4fe115c3da63",
+   "execution_count": 3,
+   "id": "bd5c413e-bb94-4c56-9166-c2a25c09d73d",
    "metadata": {},
    "outputs": [
     {
@@ -417,302 +50,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "0d81212a-2790-4e9d-bb59-52d183287fa1",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                                                                "
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭───────── SyftClient.email = 'andrew@openmined.org' ─────────╮\n",
-       "│                                                             │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.folder</span> = /Users/atrask/SyftBox_andrew@openmined.org       │\n",
-       "│                                                             │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.platforms</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(for peer-to-peer communication)</span>                │\n",
-       "│    <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">.google_org</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(project: psychic-surf-472920-j9)</span>  │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gmail</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                                   │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gdrive_files</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                            │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gsheets</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 peers)</span>                                 │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008000; text-decoration-color: #008000\">.gforms</span>                                            │\n",
-       "│                                                             │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span>         │\n",
-       "│                                                             │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">.peers</span>  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(3 active, 0 pending)</span>                              │\n",
-       "│                                                             │\n",
-       "│    [0] rasswanth@openmined.org                              │\n",
-       "│    [1] liamtrask@gmail.com                                  │\n",
-       "│    [2] kj@kj.dev                                            │\n",
-       "│                                                             │\n",
-       "╰─────────────────────────────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭───────── SyftClient.email = 'andrew@openmined.org' ─────────╮\n",
-       "│                                                             │\n",
-       "│  \u001b[2m.folder\u001b[0m = /Users/atrask/SyftBox_andrew@openmined.org       │\n",
-       "│                                                             │\n",
-       "│  \u001b[2m.platforms\u001b[0m \u001b[2m(for peer-to-peer communication)\u001b[0m                │\n",
-       "│    \u001b[1;33m.google_org\u001b[0m \u001b[2m(3 peers)\u001b[0m \u001b[2m(project: psychic-surf-472920-j9)\u001b[0m  │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gmail\u001b[0m \u001b[2m(3 peers)\u001b[0m                                   │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gdrive_files\u001b[0m \u001b[2m(3 peers)\u001b[0m                            │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gsheets\u001b[0m \u001b[2m(3 peers)\u001b[0m                                 │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[32m✓\u001b[0m \u001b[32m.gforms\u001b[0m                                            │\n",
-       "│                                                             │\n",
-       "│  \u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m\u001b[2m━\u001b[0m         │\n",
-       "│                                                             │\n",
-       "│  \u001b[1;36m.peers\u001b[0m  \u001b[2m(3 active, 0 pending)\u001b[0m                              │\n",
-       "│                                                             │\n",
-       "│    [0] rasswanth@openmined.org                              │\n",
-       "│    [1] liamtrask@gmail.com                                  │\n",
-       "│    [2] kj@kj.dev                                            │\n",
-       "│                                                             │\n",
-       "╰─────────────────────────────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28b12a57-0308-4b0b-8ac5-be4f88586009",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b57cd0cf-847b-48f5-bbf6-1fd1b1a238aa",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "885b805d-c5bd-4f0b-a2e4-adf21dff6e64",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d1b63ae7-09a8-4cf2-8713-ce937d173bf0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "e44747c3-41ab-4534-a4cc-a18c20b24c6a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Contacts (1): andrew@openmined.org"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client1.contacts"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "1b121399-645e-42d3-aa9c-e670c940f2a3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "📬 You have 2 pending contact requests:\n",
-      "   • kj@kj.dev (via google_org.gdrive_files)\n",
-      "   • rasswanth@openmined.org (via google_org.gdrive_files)\n",
-      "\n",
-      "To accept a contact request, use: client.add_contact('email@example.com')\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'google_org.gdrive_files': [ContactRequest(from='kj@kj.dev', via=google_org.gdrive_files, 0 resources),\n",
-       "  ContactRequest(from='rasswanth@openmined.org', via=google_org.gdrive_files, 0 resources)]}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client2.check_contact_requests()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e0019277-96e2-47fc-9f60-232a141a33ad",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3542226a-d330-4262-ab05-940eddf3844b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 4,
-   "id": "88fd975e-03a0-42c0-b32c-0f5a0d8b94b6",
+   "id": "e22d5fe0-ec6c-45fe-a315-25099d3fb679",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭──────────── Contact: andrew ─────────────╮\n",
-       "│                                          │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">Email:</span> andrew@openmined.org             │\n",
-       "│  <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">Platform:</span> google_personal               │\n",
-       "│                                          │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Added: 2025-09-26 18:48</span>                 │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">Capabilities updated: 2025-09-26 18:48</span>  │\n",
-       "│                                          │\n",
-       "│  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.platforms</span>                              │\n",
-       "│    <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">.google_personal</span>                      │\n",
-       "│      <span style=\"color: #800000; text-decoration-color: #800000\">✗</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.gdrive_files</span>                     │\n",
-       "│      <span style=\"color: #800000; text-decoration-color: #800000\">✗</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">.gforms</span>                           │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008080; text-decoration-color: #008080\">.gmail</span>                            │\n",
-       "│         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">verified 0 minutes ago</span>           │\n",
-       "│      <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #008080; text-decoration-color: #008080\">.gsheets</span>                          │\n",
-       "│         <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">verified 0 minutes ago</span>           │\n",
-       "│                                          │\n",
-       "╰──────────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭──────────── Contact: andrew ─────────────╮\n",
-       "│                                          │\n",
-       "│  \u001b[1;36mEmail:\u001b[0m andrew@openmined.org             │\n",
-       "│  \u001b[1;36mPlatform:\u001b[0m google_personal               │\n",
-       "│                                          │\n",
-       "│  \u001b[2mAdded: 2025-09-26 18:48\u001b[0m                 │\n",
-       "│  \u001b[2mCapabilities updated: 2025-09-26 18:48\u001b[0m  │\n",
-       "│                                          │\n",
-       "│  \u001b[2m.platforms\u001b[0m                              │\n",
-       "│    \u001b[1;33m.google_personal\u001b[0m                      │\n",
-       "│      \u001b[31m✗\u001b[0m \u001b[2m.gdrive_files\u001b[0m                     │\n",
-       "│      \u001b[31m✗\u001b[0m \u001b[2m.gforms\u001b[0m                           │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[36m.gmail\u001b[0m                            │\n",
-       "│         \u001b[2mverified 0 minutes ago\u001b[0m           │\n",
-       "│      \u001b[32m✓\u001b[0m \u001b[36m.gsheets\u001b[0m                          │\n",
-       "│         \u001b[2mverified 0 minutes ago\u001b[0m           │\n",
-       "│                                          │\n",
-       "╰──────────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "client1.contacts[0]"
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "f = open('/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt', 'w')\n",
+    "f.write(\"Hello world?\")\n",
+    "f.close()\n",
+    "\n",
+    "path = \"/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt\"\n",
+    "\n",
+    "temp_dir = tempfile.TemporaryDirectory()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "fba3e2fe-618a-4ce1-8111-ed3fc2aec444",
+   "id": "9a7ef42e-1974-4b83-9f5a-3d96de23c8e9",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🔄 Adding andrew@openmined.org on google_personal.gdrive_files...\n",
-      "   ✅ Added on google_personal.gdrive_files\n",
-      "🔄 Adding andrew@openmined.org on google_personal.gmail...\n",
-      "   ✅ Added on google_personal.gmail\n",
-      "🔄 Adding andrew@openmined.org on google_personal.gsheets...\n",
-      "   ✅ Added on google_personal.gsheets\n",
       "\n",
-      "✅ Contact andrew@openmined.org added successfully on 3 transport(s)\n",
-      "   • google_personal.gdrive_files\n",
-      "   • google_personal.gmail\n",
-      "   • google_personal.gsheets\n"
+      "🔄 Transport negotiation for andrew@openmined.org:\n",
+      "   File size: 514.0B\n",
+      "   Priority: normal\n",
+      "\n",
+      "   Scores:\n",
+      "   - gsheets: 0.86 (est. 500ms)\n",
+      "     • Sub-second latency\n",
+      "     • Verified transport\n",
+      "   - gmail: 0.72 (est. 2000ms)\n",
+      "     • Fast latency (<5s)\n",
+      "     • Verified transport\n",
+      "   - gdrive_files: 0.68 (est. 3000ms)\n",
+      "     • Fast latency (<5s)\n",
+      "     • Verified transport\n",
+      "\n",
+      "   ✅ Selected: gsheets\n",
+      "📊 Sent message via sheets: msg_20250927_205036_75333fbe\n",
+      "   Size: 514 bytes\n",
+      "✅ Successfully sent via gsheets in 1823ms\n"
      ]
     }
    ],
    "source": [
-    "client1.add_contact(\"andrew@openmined.org\")\n",
-    "contact = client1.contacts[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "6b0e8ce2-ab68-475a-90f7-10ca77ea2ecf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "contact.platforms.google_personal.gdrive_files"
+    "out = client1.send_to(path=path, recipient=\"andrew@openmined.org\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "94438e51-af4a-43af-97cc-7556c6277a9a",
+   "id": "1049881e-d13c-4a16-b1c9-6d33a0859166",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📬 Checking inbox for messages from liamtrask@gmail.com...\n",
+      "\n",
+      "🔄 Checking gdrive_files...\n",
+      "   📭 No messages\n",
+      "\n",
+      "🔄 Checking gsheets...\n",
+      "   Found message sheet: syft_liamtrask_at_gmail_com_to_andrew_at_openmined_org_messages\n",
+      "   📥 Extracted: datasites\n",
+      "   📥 Extracted: datasites\n",
+      "   📦 Archived 2 messages\n",
+      "   ✅ Found 2 messages\n",
+      "\n",
+      "🔄 Checking gmail...\n",
+      "   ⚠️  Transport doesn't support inbox checking\n",
+      "\n",
+      "📊 Summary: Found 2 messages across 1 transport\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'email': 'andrew@openmined.org',\n",
-       " 'transport': 'gforms',\n",
-       " 'platform': 'google_personal',\n",
-       " 'available': True}"
+       "{'gsheets': [{'id': 'msg_20250927_204908_1e95aadf',\n",
+       "   'timestamp': '2025-09-27 20:49:09',\n",
+       "   'size': 514,\n",
+       "   'metadata': {'message_id': 'msg_20250927_204908_1e95aadf',\n",
+       "    'sender': 'liamtrask@gmail.com',\n",
+       "    'recipient': 'andrew@openmined.org',\n",
+       "    'created_at': '2025-09-27T20:49:08.082102',\n",
+       "    'syft_version': '0.1.0'},\n",
+       "   'extracted_to': '/Users/atrask/SyftBox_andrew@openmined.org'},\n",
+       "  {'id': 'msg_20250927_205036_75333fbe',\n",
+       "   'timestamp': '2025-09-27 20:50:37',\n",
+       "   'size': 514,\n",
+       "   'metadata': {'message_id': 'msg_20250927_205036_75333fbe',\n",
+       "    'sender': 'liamtrask@gmail.com',\n",
+       "    'recipient': 'andrew@openmined.org',\n",
+       "    'created_at': '2025-09-27T20:50:36.485574',\n",
+       "    'syft_version': '0.1.0'},\n",
+       "   'extracted_to': '/Users/atrask/SyftBox_andrew@openmined.org'}]}"
       ]
      },
      "execution_count": 7,
@@ -721,90 +161,82 @@
     }
    ],
    "source": [
-    "contact.platforms.google_personal.gforms"
+    "client2.peers['liamtrask@gmail.com'].check_inbox()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "452b4bf1-a36d-44ab-be71-0c83218d4990",
+   "execution_count": null,
+   "id": "63be0a27-fba6-4679-866d-894216af82a3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭─ Platforms for andrew@openmined.org ─╮\n",
-       "│ <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> <span style=\"color: #808000; text-decoration-color: #808000\">.google_personal</span> <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">(1 resources)</span>     │\n",
-       "╰──────────────────────────────────────╯\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "╭─ Platforms for andrew@openmined.org ─╮\n",
-       "│ \u001b[32m✓\u001b[0m \u001b[33m.google_personal\u001b[0m \u001b[2m(1 resources)\u001b[0m     │\n",
-       "╰──────────────────────────────────────╯\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc42be27-83d0-4bef-bbc4-b10d1fb9880b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "babfa261-625e-408f-bd6f-1d51524f9fe0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "80b650b0-8e11-460a-a289-203d6a374e2a",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "contact.platforms"
+    "peer = client2.peers[1]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "c669f603-df30-4f8e-af47-78538e977e2a",
+   "execution_count": 5,
+   "id": "1436bf45-a62b-40f0-b613-82a586608440",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🔄 Adding andrew@openmined.org on google_personal.gdrive_files...\n",
-      "   ✅ Added on google_personal.gdrive_files\n",
-      "🔄 Adding andrew@openmined.org on google_personal.gmail...\n",
-      "   ✅ Added on google_personal.gmail\n",
-      "🔄 Adding andrew@openmined.org on google_personal.gsheets...\n",
-      "   ✅ Added on google_personal.gsheets\n",
+      "📬 Checking inbox for messages from kj@kj.dev...\n",
       "\n",
-      "✅ Contact andrew@openmined.org added successfully on 3 transport(s)\n",
-      "   • google_personal.gdrive_files\n",
-      "   • google_personal.gmail\n",
-      "   • google_personal.gsheets\n"
+      "🔄 Checking gdrive_files...\n",
+      "   📭 No messages\n",
+      "\n",
+      "🔄 Checking gsheets...\n",
+      "   No message sheet found: syft_kj@kj.dev_to_andrew@openmined.org_outbox_inbox\n",
+      "   📭 No messages\n",
+      "\n",
+      "🔄 Checking gmail...\n",
+      "   ⚠️  Transport doesn't support inbox checking\n",
+      "\n",
+      "📊 Summary: Found 0 messages across 0 transports\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "True"
+       "{}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "client1.add_contact(\"andrew@openmined.org\")"
+    "peer.check_inbox()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5c879794-502e-408e-9b7c-7e02e9ee4533",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -816,33 +248,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
+   "id": "4fc4ca8f-c83e-4f84-8c80-02cfb231ba98",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/atrask/SyftBox_liamtrask@gmail.com'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client1.folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "89747f50-213a-4dac-9d98-e9412516cfd3",
    "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'SyncManager' object has no attribute 'transport'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 9\u001b[39m\n\u001b[32m      5\u001b[39m path = \u001b[33m\"\u001b[39m\u001b[33m/Users/atrask/Desktop/Laboratory/syft-client/test_notebooks/test_msg.txt\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      7\u001b[39m temp_dir = tempfile.TemporaryDirectory()\n\u001b[32m----> \u001b[39m\u001b[32m9\u001b[39m (msg_id, msg_path, archive_size) = \u001b[43mclient1\u001b[49m\u001b[43m.\u001b[49m\u001b[43msync\u001b[49m\u001b[43m.\u001b[49m\u001b[43mtransport\u001b[49m.prepare_message(\n\u001b[32m     10\u001b[39m   path=path,\n\u001b[32m     11\u001b[39m   recipient=\u001b[33m\"\u001b[39m\u001b[33mandrew@openmined.org\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     12\u001b[39m   temp_dir=temp_dir.name,  \u001b[38;5;66;03m# Note: use temp_dir.name to get the string path\u001b[39;00m\n\u001b[32m     13\u001b[39m   sync_from_anywhere=\u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[32m     14\u001b[39m )\n",
-      "\u001b[31mAttributeError\u001b[39m: 'SyncManager' object has no attribute 'transport'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⚠️  Syncing from outside SyftBox - file will be placed in: external/test_msg.txt\n"
      ]
     }
    ],
    "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
     "\n",
-    "f = open('test_msg.txt', 'w')\n",
+    "f = open('/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt', 'w')\n",
     "f.write(\"Hello world!!!!!!\")\n",
     "f.close()\n",
     "\n",
-    "path = \"/Users/atrask/Desktop/Laboratory/syft-client/test_notebooks/test_msg.txt\"\n",
+    "path = \"/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt\"\n",
     "\n",
     "temp_dir = tempfile.TemporaryDirectory()\n",
     "\n",
-    "(msg_id, msg_path, archive_size) = client1.sync.transport.prepare_message(\n",
+    "(msg_id, msg_path, archive_size) = client1.sync.sender.prepare_message(\n",
     "  path=path,\n",
     "  recipient=\"andrew@openmined.org\",\n",
     "  temp_dir=temp_dir.name,  # Note: use temp_dir.name to get the string path\n",
@@ -860,8 +311,116 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
+   "id": "4047f9da-870f-4b19-837b-f9a3282c9f73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, '..')\n",
+    "import syft_client as sc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "793b7189-260f-412e-82ed-457efd4d11fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "f = open('/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt', 'w')\n",
+    "f.write(\"Hello world?\")\n",
+    "f.close()\n",
+    "\n",
+    "path = \"/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt\"\n",
+    "\n",
+    "temp_dir = tempfile.TemporaryDirectory()\n",
+    "\n",
+    "out = client1.send_to(path=path, recipient=\"andrew@openmined.org\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
    "id": "b291d5b6-7618-446f-b4a6-1b029eabccde",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "🔄 Transport negotiation for andrew@openmined.org:\n",
+      "   File size: 514.0B\n",
+      "   Priority: normal\n",
+      "\n",
+      "   Scores:\n",
+      "   - gsheets: 0.86 (est. 500ms)\n",
+      "     • Sub-second latency\n",
+      "     • Verified transport\n",
+      "   - gmail: 0.72 (est. 2000ms)\n",
+      "     • Fast latency (<5s)\n",
+      "     • Verified transport\n",
+      "   - gdrive_files: 0.68 (est. 3000ms)\n",
+      "     • Fast latency (<5s)\n",
+      "     • Verified transport\n",
+      "\n",
+      "   ✅ Selected: gsheets\n",
+      "📊 Sent message via sheets: msg_20250927_204908_1e95aadf\n",
+      "   Size: 514 bytes\n",
+      "✅ Successfully sent via gsheets in 1800ms\n"
+     ]
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "7fcbea4d-b717-47f6-a6a8-51ea3585cedb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📬 Checking inbox for messages from liamtrask@gmail.com...\n",
+      "\n",
+      "🔄 Checking gdrive_files...\n",
+      "   📭 No messages\n",
+      "\n",
+      "🔄 Checking gsheets...\n",
+      "   No message sheet found: syft_liamtrask@gmail.com_to_andrew@openmined.org_outbox_inbox\n",
+      "   📭 No messages\n",
+      "\n",
+      "🔄 Checking gmail...\n",
+      "   ⚠️  Transport doesn't support inbox checking\n",
+      "\n",
+      "📊 Summary: Found 0 messages across 0 transports\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client2.peers['liamtrask@gmail.com'].check_inbox()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc742359-0055-4165-a0a5-4a8444a7ed85",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/test_notebooks/Test Sync.ipynb
+++ b/test_notebooks/Test Sync.ipynb
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "e22d5fe0-ec6c-45fe-a315-25099d3fb679",
    "metadata": {},
    "outputs": [],
@@ -64,12 +64,12 @@
     "\n",
     "path = \"/Users/atrask/SyftBox_liamtrask@gmail.com/datasites/test_msg.txt\"\n",
     "\n",
-    "temp_dir = tempfile.TemporaryDirectory()"
+    "temp_dir = tempfile.TemporaryDirectory()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "9a7ef42e-1974-4b83-9f5a-3d96de23c8e9",
    "metadata": {},
    "outputs": [
@@ -77,36 +77,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "🔄 Transport negotiation for andrew@openmined.org:\n",
-      "   File size: 514.0B\n",
-      "   Priority: normal\n",
-      "\n",
-      "   Scores:\n",
-      "   - gsheets: 0.86 (est. 500ms)\n",
-      "     • Sub-second latency\n",
-      "     • Verified transport\n",
-      "   - gmail: 0.72 (est. 2000ms)\n",
-      "     • Fast latency (<5s)\n",
-      "     • Verified transport\n",
-      "   - gdrive_files: 0.68 (est. 3000ms)\n",
-      "     • Fast latency (<5s)\n",
-      "     • Verified transport\n",
-      "\n",
-      "   ✅ Selected: gsheets\n",
-      "📊 Sent message via sheets: msg_20250927_205036_75333fbe\n",
-      "   Size: 514 bytes\n",
-      "✅ Successfully sent via gsheets in 1823ms\n"
+      "📤 Using specified transport: gsheets\n",
+      "📊 Sent message via sheets: msg_20250927_210117_520b22b9\n",
+      "   Size: 517 bytes\n",
+      "✅ Successfully sent via gsheets in 1479ms\n"
      ]
     }
    ],
    "source": [
-    "out = client1.send_to(path=path, recipient=\"andrew@openmined.org\")"
+    "out = client1.send_to(path=path, recipient=\"andrew@openmined.org\", transport=\"gsheets\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "1049881e-d13c-4a16-b1c9-6d33a0859166",
    "metadata": {},
    "outputs": [
@@ -114,54 +98,58 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "📬 Checking inbox for messages from liamtrask@gmail.com...\n",
-      "\n",
-      "🔄 Checking gdrive_files...\n",
-      "   📭 No messages\n",
+      "📬 Checking gsheets inbox for messages from liamtrask@gmail.com...\n",
       "\n",
       "🔄 Checking gsheets...\n",
       "   Found message sheet: syft_liamtrask_at_gmail_com_to_andrew_at_openmined_org_messages\n",
       "   📥 Extracted: datasites\n",
       "   📥 Extracted: datasites\n",
-      "   📦 Archived 2 messages\n",
-      "   ✅ Found 2 messages\n",
+      "   📥 Extracted: datasites\n",
+      "   📦 Archived 3 messages\n",
+      "   ✅ Found 3 messages\n",
       "\n",
-      "🔄 Checking gmail...\n",
-      "   ⚠️  Transport doesn't support inbox checking\n",
-      "\n",
-      "📊 Summary: Found 2 messages across 1 transport\n"
+      "📊 Summary: Found 3 messages across 1 transport\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'gsheets': [{'id': 'msg_20250927_204908_1e95aadf',\n",
-       "   'timestamp': '2025-09-27 20:49:09',\n",
-       "   'size': 514,\n",
-       "   'metadata': {'message_id': 'msg_20250927_204908_1e95aadf',\n",
+       "{'gsheets': [{'id': 'msg_20250927_205845_5afdf583',\n",
+       "   'timestamp': '2025-09-27 20:58:46',\n",
+       "   'size': 590,\n",
+       "   'metadata': {'message_id': 'msg_20250927_205845_5afdf583',\n",
        "    'sender': 'liamtrask@gmail.com',\n",
        "    'recipient': 'andrew@openmined.org',\n",
-       "    'created_at': '2025-09-27T20:49:08.082102',\n",
+       "    'created_at': '2025-09-27T20:58:45.346310',\n",
        "    'syft_version': '0.1.0'},\n",
        "   'extracted_to': '/Users/atrask/SyftBox_andrew@openmined.org'},\n",
-       "  {'id': 'msg_20250927_205036_75333fbe',\n",
-       "   'timestamp': '2025-09-27 20:50:37',\n",
-       "   'size': 514,\n",
-       "   'metadata': {'message_id': 'msg_20250927_205036_75333fbe',\n",
+       "  {'id': 'msg_20250927_210113_ba17de9a',\n",
+       "   'timestamp': '2025-09-27 21:01:14',\n",
+       "   'size': 513,\n",
+       "   'metadata': {'message_id': 'msg_20250927_210113_ba17de9a',\n",
        "    'sender': 'liamtrask@gmail.com',\n",
        "    'recipient': 'andrew@openmined.org',\n",
-       "    'created_at': '2025-09-27T20:50:36.485574',\n",
+       "    'created_at': '2025-09-27T21:01:13.582107',\n",
+       "    'syft_version': '0.1.0'},\n",
+       "   'extracted_to': '/Users/atrask/SyftBox_andrew@openmined.org'},\n",
+       "  {'id': 'msg_20250927_210117_520b22b9',\n",
+       "   'timestamp': '2025-09-27 21:01:18',\n",
+       "   'size': 517,\n",
+       "   'metadata': {'message_id': 'msg_20250927_210117_520b22b9',\n",
+       "    'sender': 'liamtrask@gmail.com',\n",
+       "    'recipient': 'andrew@openmined.org',\n",
+       "    'created_at': '2025-09-27T21:01:17.183517',\n",
        "    'syft_version': '0.1.0'},\n",
        "   'extracted_to': '/Users/atrask/SyftBox_andrew@openmined.org'}]}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "client2.peers['liamtrask@gmail.com'].check_inbox()"
+    "client2.peers['liamtrask@gmail.com'].check_inbox(transport=\"gsheets\")"
    ]
   },
   {


### PR DESCRIPTION
Adds peer-to-peer file messaging between syft-client users via their existing platforms (Google Drive,
  Sheets, Gmail).

  ### What's New
  - `client.add_peer("email@example.com")` - Add peers for bidirectional communication
  - `client.send_to("file.txt", "peer@email.com")` - Send files to peers
  - `peer.check_inbox()` - Receive messages from peers
  - Automatic transport selection based on file size and network conditions
  - Support for manual transport override when needed

  ### Example
  ```python
  # Setup
  client1.add_peer("friend@gmail.com")

  # Send
  client1.send_to("data.csv", "friend@gmail.com")

  # Receive
  client2.peers["you@email.com"].check_inbox()

  Renames "contacts" → "peers" throughout the codebase.
  ```