### PR TITLE
Fix Timestamp in sync

### DIFF
--- a/syft_client/sync/sync/caches/datasite_owner_cache.py
+++ b/syft_client/sync/sync/caches/datasite_owner_cache.py
@@ -64,8 +64,8 @@ class DataSiteOwnerEventCache(BaseModelCallbackMixin):
             syftbox_parent = Path(config.syftbox_folder).parent
             events_folder = syftbox_parent / f"{syftbox_folder_name}-events"
             return cls(
-                events_connection=FSFileConnection(base_dir=events_folder),
-                file_connection=FSFileConnection(base_dir=my_datasite_folder),
+                events_connection=FSFileConnection[FileChangeEvent](base_dir=events_folder),
+                file_connection=FSFileConnection[str](base_dir=my_datasite_folder),
                 email=config.email,
             )
 

--- a/syft_client/sync/sync/caches/datasite_watcher_cache.py
+++ b/syft_client/sync/sync/caches/datasite_watcher_cache.py
@@ -65,8 +65,8 @@ class DataSiteWatcherCache(BaseModel):
             events_folder = syftbox_parent / f"{syftbox_folder_name}-events"
 
             return cls(
-                events_connection=FSFileConnection(base_dir=events_folder),
-                file_connection=FSFileConnection(base_dir=config.syftbox_folder),
+                events_connection=FSFileConnection[FileChangeEvent](base_dir=events_folder),
+                file_connection=FSFileConnection[str](base_dir=config.syftbox_folder),
                 connection_router=ConnectionRouter.from_configs(
                     connection_configs=config.connection_configs
                 ),

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -382,6 +382,6 @@ with open("outputs/result.json", "w") as f:
     with open(output_path, "r") as f:
         json_content = json.loads(f.read())
 
-    assert json_content["result"] == "Hello World!"
+    assert json_content["result"] == "Hello, world!"
 
 


### PR DESCRIPTION

Changes:
- Uncommented and fixed _deserialize function to handle bytes, str, and BaseModel types
- Added UnicodeDecodeError handling for binary files stored in string-typed connections
- Updated _read_file_full_path to use generic type from class definition instead of hardcoding str
- Added generic type parameters to FSFileConnection instantiations in DataSiteWatcherCache and DataSiteOwnerEventCache
- Fixed test assertion to match actual test data ("Hello, world!" instead of "Hello World!")

All 12 unit tests in test_sync_manager.py now pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
