### PR TITLE
Per-peer timestamp tracking to DataSiteWatcherCache for multi-DOs dataset discovery

### DIFF
--- a/syft_client/sync/sync/caches/datasite_watcher_cache.py
+++ b/syft_client/sync/sync/caches/datasite_watcher_cache.py
@@ -140,7 +140,7 @@ class DataSiteWatcherCache(BaseModel):
 
         time_since_last_sync = datetime.now() - self.last_sync
         if time_since_last_sync > timedelta(seconds=SECONDS_BEFORE_SYNCING_DOWN):
-            self.sync_down()
+            self.sync_down(peer_email)
 
     def current_hash_for_file(self, path: str) -> int | None:
         for peer in self.peers:


### PR DESCRIPTION
Before the fix, if a DS connects to 2 DOs, it can only discover the dataset from 1:
<img width="1923" height="559" alt="Screenshot 2025-11-25 at 15 25 21" src="https://github.com/user-attachments/assets/9c1011da-43ad-4743-8464-16dc5bfd70c9" />

After, DS can discover datasets from both DOs
<img width="1912" height="265" alt="Screenshot 2025-11-25 at 15 25 30" src="https://github.com/user-attachments/assets/9c011366-ccf2-4f46-95c3-9c39f7106b5b" />
