### PR TITLE
fix: no self._peers attribute for SyftBoxManager

### DIFF
--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -954,5 +954,7 @@ class SyftboxManager(BaseModel):
         self.connection_router.reset_caches()
 
     def _get_all_peer_platforms(self) -> List[BasePlatform]:
-        all_platforms = set([plat for p in self._peers for plat in p.platforms])
+        all_platforms = set(
+            [plat for p in self._approved_peers for plat in p.platforms]
+        )
         return list(all_platforms)


### PR DESCRIPTION
Fix this bug:

<img width="560" height="619" alt="Screenshot 2026-01-08 at 09 37 40" src="https://github.com/user-attachments/assets/0fe81f41-411c-4771-88fc-034e055c7926" />
