### PR TITLE
feat: auto-approve by convention (params.json, email reply)

### DIFF
--- a/packages/syft-bg/src/syft_bg/api/utils.py
+++ b/packages/syft-bg/src/syft_bg/api/utils.py
@@ -14,6 +14,7 @@ from syft_bg.email_approve.pubsub_setup import get_project_id_from_credentials
 from syft_bg.common.setup_state import SetupState, SetupStatus
 
 PERMISSION_FILE_NAME = "syft.pub.yaml"
+DEFAULT_NAME_ONLY_FILES = {"params.json"}
 
 
 def get_setup_state_path(service: str) -> Path:
@@ -298,13 +299,16 @@ def resolve_auto_approve_file_args(
     Returns (content_rel_paths, name_only).
     """
     if contents is None and file_paths is None:
-        return list(user_files.keys()), []
+        all_files = set(user_files.keys())
+        name_only = all_files.intersection(DEFAULT_NAME_ONLY_FILES)
+        content_matched = all_files - name_only
+        return list(content_matched), list(name_only)
     elif contents is not None and file_paths is None:
         return list(contents), []
     elif contents is None and file_paths is not None:
         name_only = list(file_paths)
-        content_rel_paths = [rel for rel in user_files if rel not in set(file_paths)]
-        return content_rel_paths, name_only
+        content_rel_paths = set(user_files.keys()) - set(file_paths)
+        return list(content_rel_paths), name_only
     else:
         return list(contents), list(file_paths)  # type: ignore[arg-type]
 

--- a/packages/syft-bg/src/syft_bg/approve/handlers/job.py
+++ b/packages/syft-bg/src/syft_bg/approve/handlers/job.py
@@ -117,6 +117,10 @@ class JobApprovalHandler:
                     print(f"Failed to approve {job.name}: {e}")
 
         if approved_jobs:
-            self.client.process_approved_jobs(stream_output=self.verbose)
+            self.client.process_approved_jobs(
+                stream_output=self.verbose,
+                share_outputs_with_submitter=True,
+                share_logs_with_submitter=True,
+            )
 
         return approved_jobs

--- a/packages/syft-bg/src/syft_bg/email_approve/handler.py
+++ b/packages/syft-bg/src/syft_bg/email_approve/handler.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class EmailAction(Enum):
     APPROVE = "approve"
+    AUTO_APPROVE = "auto_approve"
     DENY = "deny"
     UNKNOWN = "unknown"
 
@@ -38,6 +39,9 @@ def parse_reply(text: str) -> EmailApprovalResponse:
             continue
 
         lower = line.lower()
+        if lower.startswith(("auto-approve", "auto approve", "autoapprove")):
+            return EmailApprovalResponse(action=EmailAction.AUTO_APPROVE)
+
         if lower.startswith("approve") or lower.startswith("aprove"):
             return EmailApprovalResponse(action=EmailAction.APPROVE)
 
@@ -100,6 +104,8 @@ class EmailApproveHandler:
 
         if response.action == EmailAction.APPROVE:
             self._approve_job(job, job_name, state_key)
+        elif response.action == EmailAction.AUTO_APPROVE:
+            self._auto_approve_job(job, job_name, state_key)
         elif response.action == EmailAction.DENY:
             self._reject_job(job, job_name, response.reason or "", state_key)
 
@@ -120,6 +126,20 @@ class EmailApproveHandler:
             share_logs_with_submitter=True,
         )
         print(f"[EmailApproveHandler] Approved job: {job_name}")
+
+    def _auto_approve_job(self, job, job_name: str, state_key: str) -> None:
+        """Approve a job and create an auto-approval object for future jobs."""
+        self._approve_job(job, job_name, state_key)
+
+        from syft_bg.api.api import auto_approve_job
+
+        result = auto_approve_job(job)
+        if result.success:
+            print(f"[EmailApproveHandler] Auto-approval created for: {job_name}")
+        else:
+            print(
+                f"[EmailApproveHandler] Failed to create auto-approval for {job_name}: {result.error}"
+            )
 
     def _reject_job(self, job, job_name: str, reason: str, state_key: str) -> None:
         """Reject a job with a reason."""

--- a/tests/unit/syft_bg/test_email_approve.py
+++ b/tests/unit/syft_bg/test_email_approve.py
@@ -1,6 +1,6 @@
 """Tests for email-based job approval: reply parsing, handler, and gmail_watch helpers."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -71,6 +71,29 @@ class TestParseReply:
             "deny this code accesses private data"
         ) == EmailApprovalResponse(
             action=EmailAction.DENY, reason="this code accesses private data"
+        )
+
+    def test_auto_approve_hyphenated(self):
+        assert parse_reply("auto-approve") == EmailApprovalResponse(
+            action=EmailAction.AUTO_APPROVE
+        )
+
+    def test_auto_approve_space(self):
+        assert parse_reply("auto approve") == EmailApprovalResponse(
+            action=EmailAction.AUTO_APPROVE
+        )
+
+    def test_autoapprove_no_separator(self):
+        assert parse_reply("autoapprove") == EmailApprovalResponse(
+            action=EmailAction.AUTO_APPROVE
+        )
+
+    def test_auto_approve_case_insensitive(self):
+        assert parse_reply("Auto-Approve") == EmailApprovalResponse(
+            action=EmailAction.AUTO_APPROVE
+        )
+        assert parse_reply("AUTO APPROVE") == EmailApprovalResponse(
+            action=EmailAction.AUTO_APPROVE
         )
 
     def test_whitespace_only(self):
@@ -193,6 +216,31 @@ class TestEmailApproveHandler:
         mock_job.reset_mock()
         handler.handle_reply(thread_id="thread_dup", reply_text="approve")
         mock_job.approve.assert_not_called()
+
+    def test_auto_approve_job(self, tmp_path):
+        handler, job_client, job_runner, state, notify_state = self._make_handler(
+            tmp_path
+        )
+
+        notify_state.store_thread_id("test.job", "thread_auto")
+
+        mock_job = MagicMock()
+        mock_job.name = "test.job"
+        mock_job.status = "pending"
+        mock_job.submitted_by = "ds@example.com"
+        job_client.jobs = [mock_job]
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        with patch(
+            "syft_bg.api.api.auto_approve_job",
+            return_value=mock_result,
+        ) as mock_auto:
+            handler.handle_reply(thread_id="thread_auto", reply_text="auto-approve")
+
+        mock_job.approve.assert_called_once()
+        job_runner.process_approved_jobs.assert_called_once()
+        mock_auto.assert_called_once_with(mock_job)
 
     def test_job_not_pending(self, tmp_path):
         handler, job_client, _, state, notify_state = self._make_handler(tmp_path)

--- a/tests/unit/syft_bg/test_email_auto_approve_flow.py
+++ b/tests/unit/syft_bg/test_email_auto_approve_flow.py
@@ -1,0 +1,253 @@
+"""E2E test for email auto-approve: reply 'auto-approve' creates an auto-approval object."""
+
+import base64
+import json
+import tempfile
+from contextlib import contextmanager
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from syft_bg.approve.config import AutoApproveConfig
+from syft_bg.approve.orchestrator import ApprovalOrchestrator
+from syft_bg.common.config import get_default_paths
+from syft_bg.common.state import JsonStateManager
+from syft_bg.email_approve.gmail_message import GmailMessage
+from syft_bg.email_approve.handler import EmailApproveHandler
+from syft_bg.email_approve.monitor import EmailApproveMonitor
+from syft_bg.notify.config import NotifyConfig
+from syft_bg.notify.gmail.sender import SendResult
+from syft_bg.notify.handlers.job import JobHandler
+from syft_bg.notify.monitors.job import JobMonitor
+from syft_bg.notify.orchestrator import NotificationOrchestrator
+from syft_client.sync.syftbox_manager import SyftboxManager
+
+FAKE_THREAD_ID = "thread_auto_approve_123"
+
+
+@contextmanager
+def _temp_config_paths():
+    """Redirect config and auto_approvals_dir to a temp directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        original = get_default_paths()
+        patched = replace(
+            original,
+            config=tmp_path / "config.yaml",
+            auto_approvals_dir=tmp_path / "auto_approvals",
+        )
+        with (
+            patch("syft_bg.common.config.get_default_paths", return_value=patched),
+            patch("syft_bg.approve.config.get_default_paths", return_value=patched),
+        ):
+            yield patched
+
+
+def _make_notify_orchestrator(
+    do_manager: SyftboxManager,
+    tmp: Path,
+) -> tuple[NotificationOrchestrator, JsonStateManager, MagicMock]:
+    """Create a NotificationOrchestrator with a mocked GmailSender."""
+    notify_state = JsonStateManager(tmp / "notify_state.json")
+
+    mock_sender = MagicMock()
+    mock_sender.notify_new_job.return_value = SendResult(
+        success=True, thread_id=FAKE_THREAD_ID
+    )
+
+    job_handler = JobHandler(
+        sender=mock_sender,
+        state=notify_state,
+        do_email=do_manager.email,
+        syftbox_root=Path(do_manager.syftbox_folder),
+    )
+
+    job_monitor = JobMonitor(
+        syftbox_root=Path(do_manager.syftbox_folder),
+        do_email=do_manager.email,
+        handler=job_handler,
+        state=notify_state,
+    )
+    job_monitor._is_fresh_state = False
+
+    notify_config = NotifyConfig(
+        do_email=do_manager.email,
+        syftbox_root=Path(do_manager.syftbox_folder),
+    )
+    orchestrator = NotificationOrchestrator(
+        config=notify_config,
+        job_monitor=job_monitor,
+    )
+    return orchestrator, notify_state, mock_sender
+
+
+def _make_email_approve_orchestrator(
+    do_manager: SyftboxManager,
+    notify_state: JsonStateManager,
+    tmp: Path,
+    reply_text: str = "auto-approve",
+) -> tuple[EmailApproveMonitor, JsonStateManager, MagicMock]:
+    """Create email approve components with mocked GmailWatcher."""
+    do_email = do_manager.email
+
+    email_approve_state = JsonStateManager(tmp / "email_approve_state.json")
+    email_approve_state.set_data("email_approve_last_history_id", "10000")
+
+    handler = EmailApproveHandler(
+        job_client=do_manager.job_client,
+        job_runner=do_manager.job_runner,
+        state=email_approve_state,
+        notify_state=notify_state,
+        do_email=do_email,
+    )
+
+    mock_watcher = MagicMock()
+    mock_watcher.list_history_message_ids.return_value = ({"msg_001"}, "12345")
+    mock_watcher.get_message.return_value = GmailMessage(
+        {
+            "threadId": FAKE_THREAD_ID,
+            "payload": {
+                "mimeType": "text/plain",
+                "headers": [{"name": "From", "value": do_email}],
+                "body": {
+                    "data": base64.urlsafe_b64encode(reply_text.encode()).decode(),
+                },
+            },
+        }
+    )
+
+    monitor = EmailApproveMonitor(
+        watcher=mock_watcher,
+        handler=handler,
+        state=email_approve_state,
+        credentials=MagicMock(),
+        subscription_path="projects/fake/subscriptions/fake-sub",
+        topic_name="projects/fake/topics/fake-topic",
+        do_email=do_email,
+    )
+
+    return monitor, email_approve_state, mock_watcher
+
+
+def _create_project_code_files_with_json_contents(params: dict) -> Path:
+    """Create a project dir with main.py and params.json."""
+    project_dir = Path(tempfile.mkdtemp(prefix="test_email_auto_approve_"))
+    (project_dir / "main.py").write_text(
+        """import json
+from pathlib import Path
+script_dir = Path(__file__).parent
+with open(script_dir / "params.json", "r") as f:
+    params = json.load(f)
+with open("outputs/result.json", "w") as f:
+    json.dump({"params": params, "status": "done"}, f)
+"""
+    )
+    (project_dir / "params.json").write_text(json.dumps(params))
+    return project_dir
+
+
+def test_email_auto_approve_creates_object_and_approves_future_jobs():
+    """Full flow: auto-approve reply creates approval object, second job is auto-approved."""
+
+    ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+        use_in_memory_cache=False,
+        sync_automatically=False,
+    )
+
+    tmp = Path(tempfile.mkdtemp(prefix="test_email_auto_approve_"))
+
+    with _temp_config_paths():
+        # -- Step 1: Submit first job with params.json --
+        project_dir = _create_project_code_files_with_json_contents({"run": 1})
+        ds_manager.submit_python_job(
+            user=do_manager.email,
+            code_path=str(project_dir),
+            job_name="auto_approve_test.job",
+            entrypoint="main.py",
+        )
+        do_manager.sync()
+
+        assert len(do_manager.jobs) == 1
+        assert do_manager.jobs[0].status == "pending"
+        job_name = do_manager.jobs[0].name
+
+        # -- Step 2: Notify orchestrator sends email --
+        notify_orchestrator, notify_state, mock_sender = _make_notify_orchestrator(
+            do_manager, tmp
+        )
+        notify_orchestrator.run_once()
+
+        mock_sender.notify_new_job.assert_called_once()
+        assert notify_state.get_thread_id(job_name) == FAKE_THREAD_ID
+
+        # -- Step 3: Simulate "auto-approve" email reply --
+        monitor, email_approve_state, mock_watcher = _make_email_approve_orchestrator(
+            do_manager, notify_state, tmp, reply_text="auto-approve"
+        )
+
+        mock_pubsub_message = MagicMock()
+        mock_pubsub_message.data = json.dumps({"historyId": "12345"}).encode("utf-8")
+
+        monitor._on_pubsub_message(mock_pubsub_message)
+        history_id, msg = monitor._history_queue.get(timeout=5)
+        monitor._process_history(history_id)
+        msg.ack()
+
+        # -- Step 4: Verify first job done and DS gets results --
+        assert do_manager.jobs[0].status == "done"
+
+        do_manager.sync()
+        ds_manager.sync()
+        ds_job = [j for j in ds_manager.jobs if j.name == job_name][0]
+        assert len(ds_job.output_paths) > 0
+
+        result = json.loads(ds_job.output_paths[0].read_text())
+        assert result["params"]["run"] == 1
+
+        # -- Step 5: Verify auto-approve object was created correctly --
+        config = AutoApproveConfig.load()
+        obj = config.auto_approvals.objects[job_name]
+        content_names = {e.relative_path for e in obj.file_contents}
+        assert content_names == {"main.py"}
+        assert obj.file_paths == ["params.json"]
+        assert obj.peers == [ds_manager.email]
+
+        # -- Step 6: Submit second job with same main.py, different params --
+        project_dir_2 = _create_project_code_files_with_json_contents({"run": 2})
+        ds_manager.submit_python_job(
+            user=do_manager.email,
+            code_path=str(project_dir_2),
+            job_name="auto_approve_test_2.job",
+            entrypoint="main.py",
+        )
+        do_manager.sync()
+
+        second_job = [
+            j for j in do_manager.jobs if j.name == "auto_approve_test_2.job"
+        ][0]
+        assert second_job.status == "pending"
+
+        # -- Step 7: Run approval orchestrator — should auto-approve --
+        approve_config = AutoApproveConfig.load()
+        approve_config.do_email = do_manager.email
+        approve_config.syftbox_root = do_manager.syftbox_folder
+        approve_config.approve_state_path = tmp / "approve_state.json"
+
+        orchestrator = ApprovalOrchestrator(client=do_manager, config=approve_config)
+        orchestrator.run_once(monitor_type="jobs")
+
+        # -- Step 8: Verify second job auto-approved and DS gets results --
+        second_job = [
+            j for j in do_manager.jobs if j.name == "auto_approve_test_2.job"
+        ][0]
+        assert second_job.status == "done"
+
+        do_manager.sync()
+        ds_manager.sync()
+        ds_job_2 = [j for j in ds_manager.jobs if j.name == "auto_approve_test_2.job"][
+            0
+        ]
+        assert len(ds_job_2.output_paths) > 0
+
+        result_2 = json.loads(ds_job_2.output_paths[0].read_text())
+        assert result_2["params"]["run"] == 2

--- a/tests/unit/test_job_auto_approval.py
+++ b/tests/unit/test_job_auto_approval.py
@@ -268,3 +268,47 @@ def test_auto_approve_job_nested_directory():
             stored_content = Path(entry.path).read_text(encoding="utf-8")
             original = job.code_dir / entry.relative_path
             assert stored_content == original.read_text(encoding="utf-8")
+
+
+def test_auto_approve_job_default_no_special_treatment_for_non_params_json():
+    """Default behavior with non-params.json files: all are content-matched."""
+    ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+        use_in_memory_cache=False,
+        sync_automatically=False,
+    )
+    project_dir = Path(tempfile.mkdtemp(prefix="test_auto_approve_job_"))
+    (project_dir / "main.py").write_text("print('hello')\n")
+    (project_dir / "somefile.json").write_text('{"k": "v"}')
+    job = _submit_job_and_sync(ds_manager, do_manager, project_dir)
+
+    with _temp_config_paths():
+        result = auto_approve_job(job)
+        assert result.success is True
+
+        config = AutoApproveConfig.load()
+        obj = config.auto_approvals.objects[job.name]
+        content_names = {e.relative_path for e in obj.file_contents}
+        assert content_names == {"main.py", "somefile.json"}
+        assert obj.file_paths == []
+
+
+def test_auto_approve_job_default_params_json_is_name_only():
+    """Default behavior: params.json is automatically name-only."""
+    ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+        use_in_memory_cache=False,
+        sync_automatically=False,
+    )
+    project_dir = Path(tempfile.mkdtemp(prefix="test_auto_approve_job_"))
+    (project_dir / "main.py").write_text("print('hello')\n")
+    (project_dir / "params.json").write_text('{"k": "v"}')
+    job = _submit_job_and_sync(ds_manager, do_manager, project_dir)
+
+    with _temp_config_paths():
+        result = auto_approve_job(job)
+        assert result.success is True
+
+        config = AutoApproveConfig.load()
+        obj = config.auto_approvals.objects[job.name]
+        content_names = {e.relative_path for e in obj.file_contents}
+        assert content_names == {"main.py"}
+        assert obj.file_paths == ["params.json"]


### PR DESCRIPTION
- Default `auto_approve_job()` now classifies `params.json` as filename-only (not content-matched), so jobs with varying params auto-approve without explicit `file_paths` arg
- Added "auto-approve" email reply action: replying "auto-approve" / "auto approve" / "autoapprove" to a job email approves it AND creates an auto-approval object for future identical jobs
- Approval service now shares outputs and logs with submitter when auto-approving jobs
- E2E test verifies full flow: auto-approve reply → object created → second job with different params auto-approved