### PR TITLE
fix: cd into code dir before running job scripts

### DIFF
--- a/packages/syft-bg/src/syft_bg/api/utils.py
+++ b/packages/syft-bg/src/syft_bg/api/utils.py
@@ -336,14 +336,22 @@ def validate_auto_approve_job_inputs(
     return None
 
 
+_GENERATED_DIRS = {".venv", "outputs", "__pycache__"}
+
+
 def get_job_user_files(job) -> dict[str, Path]:
     """Get user files from a job's code directory as {relative_path: abs_path} mapping."""
     user_files: dict[str, Path] = {}
     code_dir = job.code_dir
     if code_dir.exists():
         for f in code_dir.rglob("*"):
-            if f.is_file() and f.name != PERMISSION_FILE_NAME:
-                user_files[str(f.relative_to(code_dir))] = f
+            if not f.is_file() or f.name == PERMISSION_FILE_NAME:
+                continue
+            # Skip files inside directories generated during job execution
+            rel = f.relative_to(code_dir)
+            if rel.parts[0] in _GENERATED_DIRS:
+                continue
+            user_files[str(rel)] = f
     return user_files
 
 

--- a/packages/syft-job/src/syft_job/client.py
+++ b/packages/syft-job/src/syft_job/client.py
@@ -281,7 +281,7 @@ class JobClient(BaseJobClient):
         Generate bash script for Python job execution.
 
         Args:
-            entrypoint_path: Path to Python file to execute (e.g., "code/script.py" or "code/project_dir/main.py")
+            entrypoint_path: Filename to execute (e.g., "main.py" or "script.py")
             dependencies: List of dependencies to install
             has_pyproject: Whether the code has a pyproject.toml
 
@@ -301,33 +301,28 @@ class JobClient(BaseJobClient):
             return f"""#!/bin/bash
 set -euo pipefail
 export UV_SYSTEM_PYTHON=false
-cd {code_folder} && uv sync --python {RUN_SCRIPT_PYTHON_VERSION} && cd ..
-source {code_folder}/.venv/bin/activate
+cd {code_folder}
+uv venv --python {RUN_SCRIPT_PYTHON_VERSION}
+source .venv/bin/activate
+uv sync --python {RUN_SCRIPT_PYTHON_VERSION}
 {install_deps_cmd}
-export PYTHONPATH={code_folder}:${{PYTHONPATH:-}}
+export PYTHONPATH=.:${{PYTHONPATH:-}}
 python {entrypoint_path}
 """
         else:
-            # entrypoint_path is like "code/main.py" for single files or "code/project_dir/main.py" for folders
-            # The code folder for PYTHONPATH is always "code" or "code/project_dir"
-            parts = entrypoint_path.split("/")
-            if len(parts) > 2:
-                # folder submission: code/project_dir/main.py
-                code_folder = "/".join(parts[:2])
-            else:
-                # single file: code/main.py
-                code_folder = parts[0]  # "code"
-
-            pythonpath_cmd = f"export PYTHONPATH={code_folder}:${{PYTHONPATH:-}}"
+            # entrypoint_path is just the filename (e.g. "main.py")
+            # We cd into code/ and run from there so relative paths (like params.json) work
+            code_folder = "code"
 
             deps_str = " ".join(f'"{dep}"' for dep in all_dependencies)
             return f"""#!/bin/bash
 set -euo pipefail
 export UV_SYSTEM_PYTHON=false
+cd {code_folder}
 uv venv --python {RUN_SCRIPT_PYTHON_VERSION}
 source .venv/bin/activate
 uv pip install {deps_str}
-{pythonpath_cmd}
+export PYTHONPATH=.:${{PYTHONPATH:-}}
 python {entrypoint_path}
 """
 
@@ -394,19 +389,17 @@ python {entrypoint_path}
         if is_folder_submission:
             shutil.copytree(code_path_resolved, code_dest)
             # Entrypoint path is relative to code/
-            entrypoint_for_script = f"code/{entrypoint}"
             pyproject_path = code_dest / "pyproject.toml"
         else:
             code_dest.mkdir(parents=True)
             shutil.copy2(code_path_resolved, code_dest / code_path_resolved.name)
-            entrypoint_for_script = f"code/{entrypoint}"
             pyproject_path = None
 
         # Generate bash script for Python execution
         dependencies = dependencies or []
         has_pyproject = pyproject_path is not None and pyproject_path.exists()
         bash_script = self._generate_python_run_script(
-            entrypoint_for_script, dependencies, has_pyproject
+            entrypoint, dependencies, has_pyproject
         )
 
         # Create run.sh file

--- a/packages/syft-job/src/syft_job/job_runner.py
+++ b/packages/syft-job/src/syft_job/job_runner.py
@@ -495,7 +495,7 @@ class SyftJobRunner:
         state.save(state_file)
 
     def _move_outputs_to_review(self, submission_dir: Path, review_dir: Path) -> None:
-        inbox_outputs = submission_dir / "outputs"
+        inbox_outputs = submission_dir / "code" / "outputs"
         review_outputs = review_dir / "outputs"
         if inbox_outputs.exists() and inbox_outputs.is_dir():
             # Merge into review/outputs (which was pre-created by _prepare_outputs_dir)
@@ -512,9 +512,9 @@ class SyftJobRunner:
 
     def _prepare_outputs_dir(self, job_name: str, user: str | None = None) -> None:
         """Clear and recreate outputs dir in both inbox/ (for job cwd) and review/ (for final results)."""
-        # Create outputs/ in inbox dir so job scripts can write there
+        # Create outputs/ inside code/ dir so job scripts can write there (cwd is code/)
         submission_dir = self._resolve_submission_dir(job_name, user)
-        inbox_outputs = submission_dir / "outputs"
+        inbox_outputs = submission_dir / "code" / "outputs"
         inbox_outputs.mkdir(parents=True, exist_ok=True)
 
         # Create outputs/ in review dir with owner-only read permissions

--- a/tests/unit/syft_bg/test_email_auto_approve_flow.py
+++ b/tests/unit/syft_bg/test_email_auto_approve_flow.py
@@ -134,9 +134,7 @@ def _create_project_code_files_with_json_contents(params: dict) -> Path:
     project_dir = Path(tempfile.mkdtemp(prefix="test_email_auto_approve_"))
     (project_dir / "main.py").write_text(
         """import json
-from pathlib import Path
-script_dir = Path(__file__).parent
-with open(script_dir / "params.json", "r") as f:
+with open("params.json", "r") as f:
     params = json.load(f)
 with open("outputs/result.json", "w") as f:
     json.dump({"params": params, "status": "done"}, f)

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -751,7 +751,8 @@ with open("outputs/result.txt", "w") as f:
         assert "uv sync" not in run_script, (
             "Should NOT use 'uv sync' without pyproject.toml"
         )
-        assert "python code/main.py" in run_script, "Should run code/main.py"
+        assert "cd code" in run_script, "Should cd into code folder"
+        assert "python main.py" in run_script, "Should run main.py from code/"
 
     finally:
         shutil.rmtree(project_dir, ignore_errors=True)
@@ -822,7 +823,7 @@ dependencies = []
             "Should use 'uv sync' for folders with pyproject.toml"
         )
         assert "cd code" in run_script, "Should cd into code folder for uv sync"
-        assert "python code/main.py" in run_script, "Should run code/main.py"
+        assert "python main.py" in run_script, "Should run main.py from code/"
 
     finally:
         shutil.rmtree(project_dir, ignore_errors=True)
@@ -857,7 +858,8 @@ def test_folder_job_auto_detect_main_py():
 
         # Verify main.py was auto-detected
         run_script = (job_dir / "run.sh").read_text()
-        assert "python code/main.py" in run_script, (
+        assert "cd code" in run_script, "Should cd into code folder"
+        assert "python main.py" in run_script, (
             "Should auto-detect main.py as entrypoint"
         )
 
@@ -893,7 +895,8 @@ def test_folder_job_auto_detect_single_py():
 
         # Verify script.py was auto-detected
         run_script = (job_dir / "run.sh").read_text()
-        assert "python code/script.py" in run_script, (
+        assert "cd code" in run_script, "Should cd into code folder"
+        assert "python script.py" in run_script, (
             "Should auto-detect single .py file as entrypoint"
         )
 
@@ -1181,7 +1184,7 @@ def test_pyproject_folder_job_flow_with_dataset():
             "Should use 'uv sync' for folders with pyproject.toml"
         )
         assert "cd code" in run_script, "Should cd into code folder for uv sync"
-        assert "python code/main.py" in run_script, "Should run code/main.py"
+        assert "python main.py" in run_script, "Should run main.py from code/"
 
         # Run the job
         job.approve()


### PR DESCRIPTION
## Summary
- Job scripts now `cd` into the `code/` directory before execution so relative paths (e.g. `params.json`) resolve correctly
- Outputs directory is created inside `code/` to match the new working directory
- Generated directories (`.venv`, `outputs`, `__pycache__`) are excluded from user file collection in `get_job_user_files`
- Updated tests to reflect the new script structure

## Test plan
- [ ] `just test-unit-fast` passes
- [ ] Verify jobs that read `params.json` via relative path work correctly
- [ ] Verify job outputs are still moved to review directory properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)