### PR TITLE
feat(notify): email DO when job execution fails

### DIFF
--- a/packages/syft-bg/src/syft_bg/notify/email_templates/templates/base.html
+++ b/packages/syft-bg/src/syft_bg/notify/email_templates/templates/base.html
@@ -181,6 +181,10 @@
         background-color: #bee3f8;
         color: #2a4365;
       }
+      .status-error {
+        background-color: #fed7d7;
+        color: #822727;
+      }
 
       /* Responsive */
       @media screen and (max-width: 600px) {

--- a/packages/syft-bg/src/syft_bg/notify/email_templates/templates/components/info_box.html
+++ b/packages/syft-bg/src/syft_bg/notify/email_templates/templates/components/info_box.html
@@ -39,7 +39,7 @@
         {% if item.badge %}
         <span
           class="status-badge status-{{ item.badge }}"
-          style="display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 14px; font-weight: 500; {% if item.badge == 'success' %}background-color: #c6f6d5; color: #22543d;{% elif item.badge == 'pending' %}background-color: #feebc8; color: #744210;{% else %}background-color: #bee3f8; color: #2a4365;{% endif %}"
+          style="display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 14px; font-weight: 500; {% if item.badge == 'success' %}background-color: #c6f6d5; color: #22543d;{% elif item.badge == 'pending' %}background-color: #feebc8; color: #744210;{% elif item.badge == 'error' %}background-color: #fed7d7; color: #822727;{% else %}background-color: #bee3f8; color: #2a4365;{% endif %}"
           >{{ item.value }}</span
         >
         {% else %} {{ item.value }} {% endif %}

--- a/packages/syft-bg/src/syft_bg/notify/email_templates/templates/emails/job_failed_do.html
+++ b/packages/syft-bg/src/syft_bg/notify/email_templates/templates/emails/job_failed_do.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %} {% block title %}Job Failed - {{ job_name }}{%
+endblock %} {% block content %}
+<h1
+  style="color: #2d3748; font-size: 24px; font-weight: 600; margin: 0 0 16px 0"
+>
+  Job Failed
+</h1>
+
+<p
+  style="color: #4a5568; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0"
+>
+  A job failed during execution.
+</p>
+
+{% set info_items = [ {'label': 'Job Name', 'value': job_name}, {'label':
+'From', 'value': ds_email}, {'label': 'Status', 'value': 'Failed', 'badge':
+'error'} ] %} {% if return_code is not none %} {% set info_items = info_items +
+[{'label': 'Return Code', 'value': return_code}] %} {% endif %} {% if duration
+%} {% set info_items = info_items + [{'label': 'Duration', 'value': duration ~
+'s'}] %} {% endif %} {% include 'components/info_box.html' %} {% if error_output
+%}
+<h2
+  style="
+    color: #2d3748;
+    font-size: 18px;
+    font-weight: 600;
+    margin: 24px 0 12px 0;
+  "
+>
+  Error Output
+</h2>
+<div style="margin-bottom: 16px">
+  <div
+    class="code-header"
+    style="
+      background-color: #161b22;
+      color: #f85149;
+      padding: 8px 16px;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo,
+        monospace;
+      font-size: 13px;
+      font-weight: 600;
+      border-radius: 8px 8px 0 0;
+      border-bottom: 1px solid #30363d;
+    "
+  >
+    stderr
+  </div>
+  <pre
+    class="code-block"
+    style="
+      background-color: #0d1117;
+      color: #e6edf3;
+      padding: 16px;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo,
+        monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      border-radius: 0 0 8px 8px;
+      overflow-x: auto;
+      white-space: pre;
+      margin: 0;
+    "
+  >
+{{ error_output }}</pre
+  >
+</div>
+{% endif %} {% endblock %}

--- a/packages/syft-bg/src/syft_bg/notify/gmail/sender.py
+++ b/packages/syft-bg/src/syft_bg/notify/gmail/sender.py
@@ -398,6 +398,50 @@ The job has finished execution. Results are available.
 
         return self.send_email(do_email, subject, body_text, body_html, thread_id)
 
+    def notify_job_failed_to_do(
+        self,
+        do_email: str,
+        job_name: str,
+        ds_email: str,
+        error_output: Optional[str] = None,
+        return_code: Optional[int] = None,
+        duration: Optional[int] = None,
+        thread_id: Optional[str] = None,
+    ) -> SendResult:
+        """Notify DO that a job failed during execution."""
+        subject = f"Re: Job: {job_name}" if thread_id else f"Job Failed: {job_name}"
+        rc_text = f"\nReturn Code: {return_code}" if return_code is not None else ""
+        duration_text = f"\nDuration: {duration}s" if duration else ""
+        body_text = f"""Job failed!
+
+Job: {job_name}
+From: {ds_email}{rc_text}{duration_text}
+
+The job failed during execution.
+"""
+        if error_output:
+            body_text += (
+                f"\n--- Error Output ---\n{error_output}\n--- End Error Output ---\n"
+            )
+
+        body_html = None
+        if self.use_html and self.renderer:
+            try:
+                body_html = self.renderer.render(
+                    "emails/job_failed_do.html",
+                    {
+                        "job_name": job_name,
+                        "ds_email": ds_email,
+                        "error_output": error_output,
+                        "return_code": return_code,
+                        "duration": duration,
+                    },
+                )
+            except Exception:
+                pass
+
+        return self.send_email(do_email, subject, body_text, body_html, thread_id)
+
     def notify_job_rejected_to_do(
         self,
         do_email: str,

--- a/packages/syft-bg/src/syft_bg/notify/handlers/job.py
+++ b/packages/syft-bg/src/syft_bg/notify/handlers/job.py
@@ -29,6 +29,33 @@ def _read_job_code(job_client: "JobClient", job_name: str) -> Optional[dict[str,
     return code_files if code_files else None
 
 
+def _read_job_stderr(
+    job_client: "JobClient", job_name: str
+) -> tuple[Optional[str], Optional[int]]:
+    """Read stderr and return code from a job's review directory."""
+    job = next((j for j in job_client.jobs if j.name == job_name), None)
+    if not job:
+        return None, None
+
+    stderr_text = None
+    stderr_file = job.job_review_path / "stderr.txt"
+    if stderr_file.exists():
+        try:
+            stderr_text = stderr_file.read_text(errors="replace").strip() or None
+        except Exception:
+            pass
+
+    return_code = None
+    rc_file = job.job_review_path / "returncode.txt"
+    if rc_file.exists():
+        try:
+            return_code = int(rc_file.read_text().strip())
+        except (ValueError, OSError):
+            pass
+
+    return stderr_text, return_code
+
+
 def _friendly_reason(reason: str, job_name: str) -> str:
     """Convert internal rejection reason to a DS-friendly message."""
     if "unknown peer" in reason:
@@ -191,6 +218,45 @@ class JobHandler:
             )
 
         return result.success
+
+    def on_job_failed(
+        self,
+        ds_email: str,
+        job_name: str,
+        duration: Optional[int] = None,
+    ) -> bool:
+        """Notify DO that a job failed during execution."""
+        if not self.notify_on_executed:
+            return False
+
+        if self.state.was_notified(job_name, "failed"):
+            print(f"[JobHandler] Skip {job_name}/failed: already notified")
+            return False
+
+        error_output, return_code = None, None
+        if self.job_client:
+            error_output, return_code = _read_job_stderr(self.job_client, job_name)
+
+        if self.do_email:
+            thread_id = self.state.get_thread_id(job_name)
+            result = self.sender.notify_job_failed_to_do(
+                self.do_email,
+                job_name,
+                ds_email,
+                error_output=error_output,
+                return_code=return_code,
+                duration=duration,
+                thread_id=thread_id,
+            )
+
+            if result.success:
+                self.state.mark_notified(job_name, "failed")
+            else:
+                print(f"[JobHandler] Failed to send failed notification for {job_name}")
+
+            return result.success
+
+        return False
 
     def on_job_rejected(
         self,

--- a/packages/syft-bg/src/syft_bg/notify/monitors/job.py
+++ b/packages/syft-bg/src/syft_bg/notify/monitors/job.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from syft_job.config import SyftJobConfig
 from syft_job.models.config import JobSubmissionMetadata
+from syft_job.models.state import JobState, JobStatus
 
 from syft_bg.common.monitor import Monitor
 from syft_bg.common.state import JsonStateManager
@@ -78,10 +79,28 @@ class JobMonitor(Monitor):
             if success:
                 print(f"[JobMonitor] Sent job approved notification: {job_name}")
 
-        if (job_path / "done").exists():
+        review_state = self._load_review_state(ds_email, job_name)
+        if review_state and review_state.status == JobStatus.FAILED:
+            success = self.handler.on_job_failed(ds_email, job_name)
+            if success:
+                print(f"[JobMonitor] Sent job failed notification: {job_name}")
+        elif (job_path / "done").exists():
             success = self.handler.on_job_executed(ds_email, job_name)
             if success:
                 print(f"[JobMonitor] Sent job executed notification: {job_name}")
+
+    def _load_review_state(self, ds_email: str, job_name: str) -> Optional[JobState]:
+        """Load state.yaml from the job's review directory."""
+        review_dir = self.job_config.get_review_job_dir(
+            self.do_email, ds_email, job_name
+        )
+        state_file = review_dir / "state.yaml"
+        if not state_file.exists():
+            return None
+        try:
+            return JobState.load(state_file)
+        except Exception:
+            return None
 
     def _load_job_metadata(self, job_path: Path) -> Optional[JobSubmissionMetadata]:
         config_file = job_path / "config.yaml"


### PR DESCRIPTION
## Summary
- Adds job failure email notification to DO with full stderr/stack trace, return code, and duration
- Dark GitHub-style code block for error output with red "stderr" header
- Conditional subject line: standalone "Job Failed: {name}" or threaded "Re: Job: {name}"
- Detects FAILED status from state.yaml before checking done marker to prevent double notifications

## Test plan
- [x] E2E tested: DS submits failing job → sync → approve → execute (fails) → notify sends email to DO
- [x] Verified email renders correctly in Gmail with stack trace
- [x] All 103 unit tests pass
- [x] Code review passed (fixed double notification bug + duration format consistency)