### PR TITLE
feat: add install/uninstall API with per-service systemd units

### DIFF
--- a/packages/syft-bg/src/syft_bg/__init__.py
+++ b/packages/syft-bg/src/syft_bg/__init__.py
@@ -4,22 +4,26 @@ from syft_bg.api import (
     AuthResult,
     AutoApproveResult,
     InitResult,
+    InstallationResult,
     StatusResult,
     auto_approve,
     auto_approve_job,
     ensure_running,
     init,
+    install,
     logs,
     restart,
     reset,
     start,
     stop,
+    uninstall,
 )
 from syft_bg.services import ServiceManager
 
 __all__ = [
     "ServiceManager",
     "InitResult",
+    "InstallationResult",
     "AuthResult",
     "auto_approve",
     "auto_approve_job",
@@ -32,7 +36,9 @@ __all__ = [
     "logs",
     "ensure_running",
     "init",
+    "install",
     "reset",
+    "uninstall",
 ]
 
 

--- a/packages/syft-bg/src/syft_bg/api/__init__.py
+++ b/packages/syft-bg/src/syft_bg/api/__init__.py
@@ -3,16 +3,19 @@ from syft_bg.api.api import (
     auto_approve_job as auto_approve_job,
     ensure_running as ensure_running,
     init as init,
+    install as install,
     logs as logs,
     reset as reset,
     restart as restart,
     start as start,
     status as status,
     stop as stop,
+    uninstall as uninstall,
 )
 from syft_bg.api.results import (
     AuthResult as AuthResult,
     AutoApproveResult as AutoApproveResult,
     InitResult as InitResult,
+    InstallationResult as InstallationResult,
     StatusResult as StatusResult,
 )

--- a/packages/syft-bg/src/syft_bg/api/api.py
+++ b/packages/syft-bg/src/syft_bg/api/api.py
@@ -3,7 +3,7 @@
 import shutil
 from pathlib import Path
 
-from syft_bg.api.results import AutoApproveResult, StatusResult
+from syft_bg.api.results import AutoApproveResult, InstallationResult, StatusResult
 from syft_bg.api.utils import (
     copy_and_hash_files,
     generate_unique_name,
@@ -20,6 +20,8 @@ from syft_bg.common.config import get_syftbg_dir, get_default_paths
 from syft_bg.common.drive import is_colab
 from syft_bg.common.syft_bg_config import SyftBgConfig
 from syft_bg.services import ServiceManager
+from syft_bg.services.base import ServiceStatus
+from syft_bg.systemd import install_service, is_installed, uninstall_service
 
 # This file should only contain user facing methods,
 # util functions should be in the utils.py file.
@@ -51,7 +53,9 @@ def init(
 
 
 def ensure_running(
-    services: dict[str, dict] | list[str], restart: bool = False
+    services: dict[str, dict] | list[str],
+    restart: bool = False,
+    install: bool = False,
 ) -> None:
     # store new settings
     try:
@@ -86,6 +90,14 @@ def ensure_running(
         else:
             manager.start_service(name)
             print(f"{name} started")
+
+    if install:
+        for name in services:
+            ok, msg = install_service(name)
+            if ok:
+                print(f"{name} installed: {msg}")
+            else:
+                print(f"{name} install failed: {msg}")
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +168,65 @@ def reset() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Systemd install
+# ---------------------------------------------------------------------------
+
+
+def install(service: str | None = None) -> list[InstallationResult]:
+    """Install syft-bg service(s) as systemd user units.
+
+    Args:
+        service: Name of a specific service to install.
+                 If None, installs all registered services.
+
+    Returns:
+        List of InstallationResult, one per service.
+    """
+    manager = ServiceManager()
+    names = [service] if service else manager.list_services()
+
+    results = []
+    for name in names:
+        if name not in manager.list_services():
+            results.append(
+                InstallationResult(
+                    success=False, service=name, message=f"Unknown service: {name}"
+                )
+            )
+            continue
+        ok, msg = install_service(name)
+        results.append(InstallationResult(success=ok, service=name, message=msg))
+    return results
+
+
+def uninstall(service: str | None = None) -> list[InstallationResult]:
+    """Uninstall syft-bg service(s) systemd user units.
+
+    Args:
+        service: Name of a specific service to uninstall.
+                 If None, uninstalls all registered services.
+
+    Returns:
+        List of InstallationResult, one per service.
+    """
+    manager = ServiceManager()
+    names = [service] if service else manager.list_services()
+
+    results = []
+    for name in names:
+        if name not in manager.list_services():
+            results.append(
+                InstallationResult(
+                    success=False, service=name, message=f"Unknown service: {name}"
+                )
+            )
+            continue
+        ok, msg = uninstall_service(name)
+        results.append(InstallationResult(success=ok, service=name, message=msg))
+    return results
+
+
 def logs(service: str, n: int = 50, as_list: bool = False) -> list[str]:
     """Get recent log lines for a service.
 
@@ -210,8 +281,6 @@ def status() -> StatusResult:
           gmail:       ready
         ...
     """
-    from syft_bg.services.base import ServiceStatus
-
     try:
         config = SyftBgConfig.from_path()
     except FileNotFoundError:
@@ -219,6 +288,7 @@ def status() -> StatusResult:
 
     manager = ServiceManager()
     services = {}
+    installed = {}
     for name, info in manager.get_all_status().items():
         svc = manager.get_service(name)
         if not svc.pid_file.parent.exists():
@@ -227,10 +297,12 @@ def status() -> StatusResult:
             services[name] = f"running (PID {info.pid})"
         else:
             services[name] = "stopped"
+        installed[name] = is_installed(name)
 
     return StatusResult(
         config=config,
         services=services,
+        installed=installed,
         is_colab=is_colab(),
     )
 

--- a/packages/syft-bg/src/syft_bg/api/results.py
+++ b/packages/syft-bg/src/syft_bg/api/results.py
@@ -97,23 +97,38 @@ class TokenStatus:
 class ServiceLine:
     """Displayable service status with text and HTML representations."""
 
-    def __init__(self, name: str, status: str, has_setup_error: bool):
+    def __init__(
+        self, name: str, status: str, has_setup_error: bool, installed: bool = False
+    ):
         self.name = name
         self.status = status
         self.has_setup_error = has_setup_error
+        self.installed = installed
+
+    def _installed_suffix(self, as_html: bool = False) -> str:
+        if self.installed:
+            if as_html:
+                return ' <span style="color:green">(installed)</span>'
+            return " (installed)"
+        if as_html:
+            return ' <span style="color:gray">(not installed)</span>'
+        return " (not installed)"
 
     def render(self, as_html: bool = False) -> str:
+        suffix = self._installed_suffix(as_html)
         if self.has_setup_error:
             if as_html:
-                return f'{self.name}: <span style="color:red">✗ setup error</span>'
-            return f"  {self.name:<16} ✗ setup error"
+                return (
+                    f'{self.name}: <span style="color:red">✗ setup error</span>{suffix}'
+                )
+            return f"  {self.name:<16} ✗ setup error{suffix}"
         if as_html:
             if "running" in self.status:
                 status = f'<span style="color:green">{self.status}</span>'
             else:
                 status = self.status
-            return f"{self.name}: {status}"
-        return f"  {self.name:<16} {self.status}"
+            return f"{self.name}: {status}{suffix}"
+        return f"  {self.name:<16} {self.status}{suffix}"
 
 
 class StatusResult(BaseModel):
@@ -123,6 +138,7 @@ class StatusResult(BaseModel):
 
     config: "SyftBgConfig"
     services: dict[str, str] = Field(default_factory=dict)
+    installed: dict[str, bool] = Field(default_factory=dict)
     is_colab: bool = False
 
     @property
@@ -168,7 +184,8 @@ class StatusResult(BaseModel):
         for name, s in self.services.items():
             setup = load_setup_state(name)
             has_error = bool(setup and setup.setup_status == SetupStatus.ERROR)
-            items.append(ServiceLine(name, s, has_error))
+            svc_installed = self.installed.get(name, False)
+            items.append(ServiceLine(name, s, has_error, installed=svc_installed))
         return items
 
     def _tokens_contents(self, as_html: bool = False) -> str:
@@ -244,6 +261,18 @@ class StatusResult(BaseModel):
         html += f"<b>tokens</b><br>{tokens_html}<br><br>"
         html += f"<b>services</b><br>{services_html}"
         return html
+
+
+class InstallationResult(BaseModel):
+    """Result of installing or uninstalling a single service."""
+
+    success: bool
+    service: str
+    message: str = ""
+
+    def __repr__(self) -> str:
+        status = "ok" if self.success else "failed"
+        return f"InstallationResult: {self.service} {status} — {self.message}"
 
 
 class AutoApproveResult(BaseModel):

--- a/packages/syft-bg/src/syft_bg/cli/commands.py
+++ b/packages/syft-bg/src/syft_bg/cli/commands.py
@@ -423,7 +423,10 @@ def init(email: str, syftbox_root: str | None, token_path: str | None):
 @click.option(
     "--restart", is_flag=True, help="Restart services even if already running"
 )
-def ensure_running(services: tuple[str, ...], restart: bool):
+@click.option(
+    "--install", is_flag=True, help="Install systemd service units for autostart"
+)
+def ensure_running(services: tuple[str, ...], restart: bool, install: bool):
     """Start services if they aren't already running.
 
     Examples:
@@ -431,10 +434,12 @@ def ensure_running(services: tuple[str, ...], restart: bool):
       syft-bg ensure-running notify approve
 
       syft-bg ensure-running notify --restart
+
+      syft-bg ensure-running notify approve --install
     """
     from syft_bg.api.api import ensure_running as api_ensure_running
 
-    api_ensure_running(list(services), restart=restart)
+    api_ensure_running(list(services), restart=restart, install=install)
 
 
 @main.command("auto-approve")
@@ -643,58 +648,64 @@ def list_auto_approvals(name: str | None):
 
 
 @main.command()
-def install():
-    """Install syft-bg as a systemd user service.
+@click.argument("service", required=False)
+def install(service: Optional[str]):
+    """Install syft-bg systemd user service(s).
 
-    This enables syft-bg to start automatically on login.
+    If SERVICE is given, install only that service. Otherwise install all.
 
     Examples:
 
       syft-bg install
 
-    After installation:
-
-      systemctl --user start syft-bg    # Start now
-      systemctl --user status syft-bg   # Check status
-      systemctl --user stop syft-bg     # Stop
+      syft-bg install notify
     """
-    from syft_bg.systemd import install_service
+    from syft_bg.api.api import install as api_install
 
-    click.echo("Installing syft-bg systemd user service...")
-    success, msg = install_service()
+    label = service or "all services"
+    click.echo(f"Installing {label}...")
+    results = api_install(service)
 
-    if success:
-        click.echo(f"✅ {msg}")
-        click.echo()
-        click.echo("To start the service now:")
-        click.echo("  systemctl --user start syft-bg")
-        click.echo()
-        click.echo("To check status:")
-        click.echo("  systemctl --user status syft-bg")
-    else:
-        click.echo(f"❌ {msg}", err=True)
+    failed = False
+    for r in results:
+        if r.success:
+            click.echo(f"  ✅ {r.service}: {r.message}")
+        else:
+            click.echo(f"  ❌ {r.service}: {r.message}", err=True)
+            failed = True
+
+    if failed:
         raise SystemExit(1)
 
 
 @main.command()
-def uninstall():
-    """Uninstall syft-bg systemd user service.
+@click.argument("service", required=False)
+def uninstall(service: Optional[str]):
+    """Uninstall syft-bg systemd user service(s).
 
-    This stops the service and removes it from systemd.
+    If SERVICE is given, uninstall only that service. Otherwise uninstall all.
 
-    Example:
+    Examples:
 
       syft-bg uninstall
+
+      syft-bg uninstall notify
     """
-    from syft_bg.systemd import uninstall_service
+    from syft_bg.api.api import uninstall as api_uninstall
 
-    click.echo("Uninstalling syft-bg systemd user service...")
-    success, msg = uninstall_service()
+    label = service or "all services"
+    click.echo(f"Uninstalling {label}...")
+    results = api_uninstall(service)
 
-    if success:
-        click.echo(f"✅ {msg}")
-    else:
-        click.echo(f"❌ {msg}", err=True)
+    failed = False
+    for r in results:
+        if r.success:
+            click.echo(f"  ✅ {r.service}: {r.message}")
+        else:
+            click.echo(f"  ❌ {r.service}: {r.message}", err=True)
+            failed = True
+
+    if failed:
         raise SystemExit(1)
 
 

--- a/packages/syft-bg/src/syft_bg/systemd/__init__.py
+++ b/packages/syft-bg/src/syft_bg/systemd/__init__.py
@@ -1,5 +1,5 @@
 """Systemd integration for syft-bg services."""
 
-from syft_bg.systemd.installer import install_service, uninstall_service
+from syft_bg.systemd.installer import install_service, is_installed, uninstall_service
 
-__all__ = ["install_service", "uninstall_service"]
+__all__ = ["install_service", "is_installed", "uninstall_service"]

--- a/packages/syft-bg/src/syft_bg/systemd/installer.py
+++ b/packages/syft-bg/src/syft_bg/systemd/installer.py
@@ -4,19 +4,18 @@ import subprocess
 import sys
 from pathlib import Path
 
-SERVICE_NAME = "syft-bg"
-SERVICE_FILE = f"{SERVICE_NAME}.service"
+SERVICE_PREFIX = "syft-bg"
 
 SERVICE_TEMPLATE = """\
 [Unit]
-Description=SyftBox Background Services
+Description=SyftBox Background Service — {service}
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=forking
-ExecStart={python} -m syft_bg start
-ExecStop={python} -m syft_bg stop
+ExecStart={python} -m syft_bg start {service}
+ExecStop={python} -m syft_bg stop {service}
 Restart=on-failure
 RestartSec=10
 
@@ -30,47 +29,62 @@ def get_systemd_user_dir() -> Path:
     return Path.home() / ".config" / "systemd" / "user"
 
 
-def get_service_path() -> Path:
-    """Get the full path to the service file."""
-    return get_systemd_user_dir() / SERVICE_FILE
+def _service_filename(service: str) -> str:
+    return f"{SERVICE_PREFIX}-{service}.service"
 
 
-def install_service() -> tuple[bool, str]:
-    """Install syft-bg as a systemd user service.
+def get_service_path(service: str) -> Path:
+    """Get the full path to a service's systemd unit file."""
+    return get_systemd_user_dir() / _service_filename(service)
+
+
+def is_installed(service: str) -> bool:
+    """Check whether a service's systemd unit file exists."""
+    return get_service_path(service).exists()
+
+
+def _daemon_reload() -> tuple[bool, str]:
+    # systemd caches unit files in memory; reload forces it to re-read from disk.
+    # needed before `enable` so systemd can find the newly written unit file.
+    result = subprocess.run(
+        ["systemctl", "--user", "daemon-reload"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return (False, f"Failed to reload systemd: {result.stderr}")
+    return (True, "")
+
+
+def install_service(service: str) -> tuple[bool, str]:
+    """Install a single syft-bg service as a systemd user unit.
 
     Returns:
         (success, message) tuple
     """
     service_dir = get_systemd_user_dir()
-    service_path = get_service_path()
+    service_path = get_service_path(service)
+    unit_name = _service_filename(service).removesuffix(".service")
 
     try:
-        # Create directory if needed
         service_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate service file with current Python interpreter
         python_path = sys.executable
-        service_content = SERVICE_TEMPLATE.format(python=python_path)
-
-        # Write service file
+        service_content = SERVICE_TEMPLATE.format(python=python_path, service=service)
         service_path.write_text(service_content)
 
-        # Reload systemd daemon
-        result = subprocess.run(
-            ["systemctl", "--user", "daemon-reload"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            return (False, f"Failed to reload systemd: {result.stderr}")
+        ok, err = _daemon_reload()
+        if not ok:
+            service_path.unlink(missing_ok=True)
+            return (False, err)
 
-        # Enable service (start on boot)
         result = subprocess.run(
-            ["systemctl", "--user", "enable", SERVICE_NAME],
+            ["systemctl", "--user", "enable", unit_name],
             capture_output=True,
             text=True,
         )
         if result.returncode != 0:
+            service_path.unlink(missing_ok=True)
             return (False, f"Failed to enable service: {result.stderr}")
 
         return (True, f"Service installed: {service_path}")
@@ -78,69 +92,42 @@ def install_service() -> tuple[bool, str]:
     except PermissionError:
         return (False, f"Permission denied writing to {service_path}")
     except FileNotFoundError:
-        return (False, "systemctl not found - systemd may not be available")
+        service_path.unlink(missing_ok=True)
+        return (False, "systemctl not found — systemd may not be available")
     except Exception as e:
+        service_path.unlink(missing_ok=True)
         return (False, str(e))
 
 
-def uninstall_service() -> tuple[bool, str]:
-    """Uninstall syft-bg systemd user service.
+def uninstall_service(service: str) -> tuple[bool, str]:
+    """Uninstall a single syft-bg service's systemd user unit.
 
     Returns:
         (success, message) tuple
     """
-    service_path = get_service_path()
+    service_path = get_service_path(service)
+    unit_name = _service_filename(service).removesuffix(".service")
 
     try:
-        # Stop service if running
         subprocess.run(
-            ["systemctl", "--user", "stop", SERVICE_NAME],
+            ["systemctl", "--user", "stop", unit_name],
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["systemctl", "--user", "disable", unit_name],
             capture_output=True,
             text=True,
         )
 
-        # Disable service
-        subprocess.run(
-            ["systemctl", "--user", "disable", SERVICE_NAME],
-            capture_output=True,
-            text=True,
-        )
-
-        # Remove service file
         if service_path.exists():
             service_path.unlink()
 
-        # Reload systemd daemon
-        subprocess.run(
-            ["systemctl", "--user", "daemon-reload"],
-            capture_output=True,
-            text=True,
-        )
+        _daemon_reload()
 
         return (True, f"Service uninstalled: {service_path}")
 
     except FileNotFoundError:
-        return (False, "systemctl not found - systemd may not be available")
-    except Exception as e:
-        return (False, str(e))
-
-
-def get_service_status() -> tuple[bool, str]:
-    """Get the status of the syft-bg systemd service.
-
-    Returns:
-        (is_active, status_text) tuple
-    """
-    try:
-        result = subprocess.run(
-            ["systemctl", "--user", "is-active", SERVICE_NAME],
-            capture_output=True,
-            text=True,
-        )
-        is_active = result.returncode == 0
-        status = result.stdout.strip()
-        return (is_active, status)
-    except FileNotFoundError:
-        return (False, "systemd not available")
+        return (False, "systemctl not found — systemd may not be available")
     except Exception as e:
         return (False, str(e))

--- a/tests/integration/syft_bg/test_cli.py
+++ b/tests/integration/syft_bg/test_cli.py
@@ -7,11 +7,13 @@ from click.testing import CliRunner
 from syft_bg.cli.commands import (
     auto_approve,
     init,
+    install,
     list_auto_approvals,
     main,
     remove_auto_approval,
     remove_peer,
     status,
+    uninstall,
 )
 
 
@@ -100,6 +102,112 @@ class TestMainCommand:
         assert "remove-auto-approval" in result.output
         assert "remove-peer" in result.output
         assert "list-auto-approvals" in result.output
+
+
+class TestInstallCommand:
+    """Tests for the install command."""
+
+    @patch("syft_bg.api.api.install")
+    def test_install_all_services(self, mock_install):
+        """Should call api.install with no service and show results."""
+        from syft_bg.api.results import InstallationResult
+
+        mock_install.return_value = [
+            InstallationResult(
+                success=True,
+                service="notify",
+                message="Service installed: /path/syft-bg-notify.service",
+            ),
+            InstallationResult(
+                success=True,
+                service="approve",
+                message="Service installed: /path/syft-bg-approve.service",
+            ),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(install, [])
+
+        assert result.exit_code == 0
+        mock_install.assert_called_once_with(None)
+        assert "notify" in result.output
+        assert "approve" in result.output
+
+    @patch("syft_bg.api.api.install")
+    def test_install_single_service(self, mock_install):
+        """Should pass service name to api.install."""
+        from syft_bg.api.results import InstallationResult
+
+        mock_install.return_value = [
+            InstallationResult(
+                success=True,
+                service="notify",
+                message="Service installed: /path/syft-bg-notify.service",
+            ),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(install, ["notify"])
+
+        assert result.exit_code == 0
+        mock_install.assert_called_once_with("notify")
+
+    @patch("syft_bg.api.api.install")
+    def test_install_failure(self, mock_install):
+        """Should exit 1 on install failure."""
+        from syft_bg.api.results import InstallationResult
+
+        mock_install.return_value = [
+            InstallationResult(
+                success=False, service="notify", message="systemctl not found"
+            ),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(install, ["notify"])
+
+        assert result.exit_code == 1
+        assert "systemctl not found" in result.output
+
+
+class TestUninstallCommand:
+    """Tests for the uninstall command."""
+
+    @patch("syft_bg.api.api.uninstall")
+    def test_uninstall_all_services(self, mock_uninstall):
+        """Should call api.uninstall with no service and show results."""
+        from syft_bg.api.results import InstallationResult
+
+        mock_uninstall.return_value = [
+            InstallationResult(
+                success=True,
+                service="notify",
+                message="Service uninstalled: /path/syft-bg-notify.service",
+            ),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(uninstall, [])
+
+        assert result.exit_code == 0
+        mock_uninstall.assert_called_once_with(None)
+
+    @patch("syft_bg.api.api.uninstall")
+    def test_uninstall_failure(self, mock_uninstall):
+        """Should exit 1 on uninstall failure."""
+        from syft_bg.api.results import InstallationResult
+
+        mock_uninstall.return_value = [
+            InstallationResult(
+                success=False, service="notify", message="systemctl not found"
+            ),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(uninstall, ["notify"])
+
+        assert result.exit_code == 1
+        assert "systemctl not found" in result.output
 
 
 class TestAutoApproveCommand:


### PR DESCRIPTION
## Summary
- Refactor systemd installer to create one unit file per service (`syft-bg-notify.service`, `syft-bg-approve.service`, etc.) instead of a single global unit
- Add `install()` and `uninstall()` functions to `api.py` with `InstallationResult` return type — CLI commands now call the API layer
- Add `install` parameter to `ensure_running()` for systemd autostart on login
- Show per-service installed/not-installed status in `status()` output
- Fix bug where failed installs left stale service files on disk
- Add 5 CLI tests for install/uninstall commands

## Test plan
- [x] All 23 CLI integration tests pass
- [x] All 285 unit tests pass
- [x] Pre-commit checks pass
- [x] Manual testing of install/uninstall API (returns proper InstallationResult, no stale files on failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)