### PR TITLE
fix: let approve service handle the trigger job in email auto-approve

### DIFF
--- a/packages/syft-bg/src/syft_bg/email_approve/handler.py
+++ b/packages/syft-bg/src/syft_bg/email_approve/handler.py
@@ -128,10 +128,10 @@ class EmailApproveHandler:
         print(f"[EmailApproveHandler] Approved job: {job_name}")
 
     def _auto_approve_job(self, job, job_name: str, state_key: str) -> None:
-        """Approve a job and create an auto-approval object for future jobs."""
-        self._approve_job(job, job_name, state_key)
-
+        """Create an auto-approval object; the approve service will pick up the trigger job."""
         from syft_bg.api.api import auto_approve_job
+
+        self.state.mark_notified(state_key, "processed")
 
         result = auto_approve_job(job)
         if result.success:

--- a/tests/unit/syft_bg/test_email_approve.py
+++ b/tests/unit/syft_bg/test_email_approve.py
@@ -238,8 +238,8 @@ class TestEmailApproveHandler:
         ) as mock_auto:
             handler.handle_reply(thread_id="thread_auto", reply_text="auto-approve")
 
-        mock_job.approve.assert_called_once()
-        job_runner.process_approved_jobs.assert_called_once()
+        mock_job.approve.assert_not_called()
+        job_runner.process_approved_jobs.assert_not_called()
         mock_auto.assert_called_once_with(mock_job)
 
     def test_job_not_pending(self, tmp_path):

--- a/tests/unit/syft_bg/test_email_auto_approve_flow.py
+++ b/tests/unit/syft_bg/test_email_auto_approve_flow.py
@@ -191,18 +191,9 @@ def test_email_auto_approve_creates_object_and_approves_future_jobs():
         monitor._process_history(history_id)
         msg.ack()
 
-        # -- Step 4: Verify first job done and DS gets results --
-        assert do_manager.jobs[0].status == "done"
-
-        do_manager.sync()
-        ds_manager.sync()
-        ds_job = [j for j in ds_manager.jobs if j.name == job_name][0]
-        assert len(ds_job.output_paths) > 0
-
-        result = json.loads(ds_job.output_paths[0].read_text())
-        assert result["params"]["run"] == 1
-
-        # -- Step 5: Verify auto-approve object was created correctly --
+        # -- Step 4: Verify auto-approve object was created correctly --
+        # The email handler only creates the AutoApprovalObj; approve service
+        # picks up the trigger job on its next tick.
         config = AutoApproveConfig.load()
         obj = config.auto_approvals.objects[job_name]
         content_names = {e.relative_path for e in obj.file_contents}
@@ -210,7 +201,10 @@ def test_email_auto_approve_creates_object_and_approves_future_jobs():
         assert obj.file_paths == ["params.json"]
         assert obj.peers == [ds_manager.email]
 
-        # -- Step 6: Submit second job with same main.py, different params --
+        # Trigger job is still pending — approve service hasn't run yet.
+        assert do_manager.jobs[0].status == "pending"
+
+        # -- Step 5: Submit second job with same main.py, different params --
         project_dir_2 = _create_project_code_files_with_json_contents({"run": 2})
         ds_manager.submit_python_job(
             user=do_manager.email,
@@ -225,7 +219,7 @@ def test_email_auto_approve_creates_object_and_approves_future_jobs():
         ][0]
         assert second_job.status == "pending"
 
-        # -- Step 7: Run approval orchestrator — should auto-approve --
+        # -- Step 6: Run approval orchestrator — should auto-approve both jobs --
         approve_config = AutoApproveConfig.load()
         approve_config.do_email = do_manager.email
         approve_config.syftbox_root = do_manager.syftbox_folder
@@ -234,7 +228,10 @@ def test_email_auto_approve_creates_object_and_approves_future_jobs():
         orchestrator = ApprovalOrchestrator(client=do_manager, config=approve_config)
         orchestrator.run_once(monitor_type="jobs")
 
-        # -- Step 8: Verify second job auto-approved and DS gets results --
+        # -- Step 7: Verify trigger job and second job both done; DS sees both --
+        trigger_job = [j for j in do_manager.jobs if j.name == job_name][0]
+        assert trigger_job.status == "done"
+
         second_job = [
             j for j in do_manager.jobs if j.name == "auto_approve_test_2.job"
         ][0]
@@ -242,10 +239,15 @@ def test_email_auto_approve_creates_object_and_approves_future_jobs():
 
         do_manager.sync()
         ds_manager.sync()
+
+        ds_job = [j for j in ds_manager.jobs if j.name == job_name][0]
+        assert len(ds_job.output_paths) > 0
+        result = json.loads(ds_job.output_paths[0].read_text())
+        assert result["params"]["run"] == 1
+
         ds_job_2 = [j for j in ds_manager.jobs if j.name == "auto_approve_test_2.job"][
             0
         ]
         assert len(ds_job_2.output_paths) > 0
-
         result_2 = json.loads(ds_job_2.output_paths[0].read_text())
         assert result_2["params"]["run"] == 2


### PR DESCRIPTION
## Summary
- When replying `auto-approve` to a job notification email, the trigger job's results never reached the DS — only subsequent matching jobs did. Reported in `notebooks/test_email_approval_extended.ipynb` (Part B): *"Email auto approval does not actually approve the job itself"*.
- Root cause: `EmailApproveHandler._auto_approve_job` called `_approve_job` (which uses `SyftJobRunner.process_approved_jobs` directly), running the job locally but never syncing back to Drive. The `email_approve` service intentionally has no `SyftboxManager`, so it can't call `client.process_approved_jobs(...)` (the version that ends with `self.sync()`).
- Fix: stop approving + running in the email handler. Just create the `AutoApprovalObj`; the existing `restart_approve_service()` brings the `approve` service back up, and on its next tick it finds the still-pending trigger job, matches it, and runs + syncs through the same code path that already works for subsequent jobs.

## Files
- `packages/syft-bg/src/syft_bg/email_approve/handler.py` — `_auto_approve_job` no longer calls `_approve_job`; just marks the email reply state processed and creates the `AutoApprovalObj`.
- `tests/unit/syft_bg/test_email_approve.py` — `test_auto_approve_job` now asserts `approve` / `process_approved_jobs` are NOT called by the handler.
- `tests/unit/syft_bg/test_email_auto_approve_flow.py` — restructured: trigger job is `pending` right after the email reply and becomes `done` after a single `ApprovalOrchestrator.run_once` (one orchestrator pass processes both trigger + second job).

## Test plan
- [x] `uv run pytest tests/unit/syft_bg/test_email_approve.py tests/unit/syft_bg/test_email_auto_approve_flow.py -xvs` — passes (28 tests).
- [x] `just test-unit-fast` — 286 passed, 1 skipped.
- [ ] End-to-end: run `notebooks/test_email_approval_extended.ipynb` Part B; reply `auto-approve` to the notification; trigger job should flip from `pending` → `done` within ~5s of the approve-service restart, no rejection email for the trigger job, DS sees outputs.