### PR TITLE
fix(syft-bg): also tear down systemd units on reset()

### DIFF
--- a/packages/syft-bg/src/syft_bg/api/api.py
+++ b/packages/syft-bg/src/syft_bg/api/api.py
@@ -156,14 +156,22 @@ def restart(service: str | None = None) -> dict[str, tuple[bool, str]]:
 
 
 def reset() -> None:
-    """Stop all services and clear all state, config, logs, and PID files."""
+    """Stop all services, uninstall systemd units, and clear all state."""
     manager = ServiceManager()
+
+    for name in manager.list_services():
+        if is_installed(name):
+            ok, msg = uninstall_service(name)
+            if not ok:
+                print(f"Warning: failed to uninstall {name}: {msg}")
+
     manager.stop_all()
 
     syftbg_dir = get_syftbg_dir()
     shutil.rmtree(syftbg_dir, ignore_errors=True)
     print(
-        "Reset complete: stopped services, cleared state, config, logs, and PID files."
+        "Reset complete: uninstalled systemd units, stopped services, "
+        "cleared state, config, logs, and PID files."
     )
 
 


### PR DESCRIPTION
## Summary
- `reset()` now uninstalls systemd user units (via the existing `uninstall_service()`) for every registered service where `is_installed()` is true, before stopping PID-tracked subprocesses and wiping `syftbg_dir`.
- Without this, units installed via `install()` would remain on disk and enabled, allowing systemd to restart the service after reset and recreate the directory — so reset wasn't actually a clean slate.
- Failed uninstalls are logged as warnings rather than aborting, so a partially-installed setup still gets cleaned up as much as possible.

## Test plan
- [x] `uv run pytest tests/unit/syft_bg -n auto` (110 passed)
- [ ] Manual smoke on a Linux box with systemd: `install()` → unit present in `~/.config/systemd/user/` → `reset()` → unit gone, `systemctl --user list-unit-files | grep syft` empty