### PR TITLE
feat(syft-job): expose approval method (manual/auto) to data scientists

### DIFF
--- a/packages/syft-bg/src/syft_bg/approve/handlers/job.py
+++ b/packages/syft-bg/src/syft_bg/approve/handlers/job.py
@@ -108,7 +108,7 @@ class JobApprovalHandler:
                 continue
 
             try:
-                job.approve()
+                job.approve(approval_method="auto")
                 approved_jobs.append(job)
 
                 if self.state:

--- a/packages/syft-bg/src/syft_bg/email_approve/handler.py
+++ b/packages/syft-bg/src/syft_bg/email_approve/handler.py
@@ -116,9 +116,11 @@ class EmailApproveHandler:
                 return job
         raise ValueError(f"Job not found: {job_name}")
 
-    def _approve_job(self, job, job_name: str, state_key: str) -> None:
+    def _approve_job(
+        self, job, job_name: str, state_key: str, approval_method: str = "manual"
+    ) -> None:
         """Approve a job, execute it, and share results."""
-        job.approve()
+        job.approve(approval_method=approval_method)
         self.state.mark_notified(state_key, "processed")
 
         self.job_runner.process_approved_jobs(
@@ -129,7 +131,7 @@ class EmailApproveHandler:
 
     def _auto_approve_job(self, job, job_name: str, state_key: str) -> None:
         """Approve a job and create an auto-approval object for future jobs."""
-        self._approve_job(job, job_name, state_key)
+        self._approve_job(job, job_name, state_key, approval_method="auto")
 
         from syft_bg.api.api import auto_approve_job
 

--- a/packages/syft-job/src/syft_job/job.py
+++ b/packages/syft-job/src/syft_job/job.py
@@ -153,10 +153,17 @@ class JobInfo:
     # Actions (write to review/)
     # ──────────────────────────────────────────────
 
-    def approve(self) -> None:
+    @property
+    def approval_method(self) -> Optional[str]:
+        return self._state.approval_method
+
+    def approve(self, approval_method: str = "manual") -> None:
         """
         Approve a job by updating state.yaml in review/.
         Only the datasite owner can approve jobs.
+
+        Args:
+            approval_method: How the job was approved ("manual" or "auto")
 
         Raises:
             ValueError: If job is not in pending status
@@ -176,6 +183,7 @@ class JobInfo:
         self._state.status = JobStatus.APPROVED
         self._state.approved_by = self.current_user_email
         self._state.approved_at = datetime.now(timezone.utc)
+        self._state.approval_method = approval_method
         self._state.save(self.job_review_path / "state.yaml")
         print(f"Job '{self.name}' approved successfully!")
 
@@ -349,10 +357,18 @@ class JobInfo:
             "failed": "💥",
         }
         emoji = status_emojis.get(self.status, "❓")
-        return f"{emoji} {self.name} ({self.status}) -> {self.datasite_owner_email}"
+        approval_info = ""
+        if self.approval_method:
+            approval_info = f" [approved: {self.approval_method}]"
+        return f"{emoji} {self.name} ({self.status}{approval_info}) -> {self.datasite_owner_email}"
 
     def __repr__(self) -> str:
-        return f"JobInfo(name='{self.name}', submitted_by='{self.submitted_by}', current_user_email='{self.current_user_email}', status='{self.status}')"
+        approval = (
+            f", approval_method='{self.approval_method}'"
+            if self.approval_method
+            else ""
+        )
+        return f"JobInfo(name='{self.name}', submitted_by='{self.submitted_by}', current_user_email='{self.current_user_email}', status='{self.status}'{approval})"
 
     def _repr_html_(self) -> str:
         return job_info_repr_html(self)

--- a/packages/syft-job/src/syft_job/job_repr.py
+++ b/packages/syft-job/src/syft_job/job_repr.py
@@ -713,6 +713,10 @@ def job_info_repr_html(job: "JobInfo") -> str:
                         <div class="syftjob-single-detail-label">Submitted:</div>
                         <div class="syftjob-single-detail-value">{submitted_time}</div>
                     </div>
+                    <div class="syftjob-single-detail">
+                        <div class="syftjob-single-detail-label">Approval:</div>
+                        <div class="syftjob-single-detail-value">{job.approval_method or "—"}</div>
+                    </div>
                 </div>
                 <div class="syftjob-single-section">
                     <h4>📜 Script</h4>
@@ -779,7 +783,9 @@ def jobs_list_str(jobs: List["JobInfo"], root_email: str) -> str:
         status_width = max(status_width, 12)
         submitted_width = max(submitted_width, 15)
 
-        header = f"{'Index':<6} {'Job Name':<{name_width}} {'Submitted By':<{submitted_width}} {'Status':<{status_width}}"
+        approval_width = 10
+
+        header = f"{'Index':<6} {'Job Name':<{name_width}} {'Submitted By':<{submitted_width}} {'Status':<{status_width}} {'Approval':<{approval_width}}"
         lines.append(header)
         lines.append("-" * len(header))
 
@@ -788,7 +794,8 @@ def jobs_list_str(jobs: List["JobInfo"], root_email: str) -> str:
         for job in sorted_jobs:
             emoji = status_emojis.get(job.status, "❓")
             status_display = f"{emoji} {job.status}"
-            line = f"[{job_index:<4}] {job.name:<{name_width}} {job.submitted_by:<{submitted_width}} {status_display:<{status_width}}"
+            approval_display = job.approval_method or "—"
+            line = f"[{job_index:<4}] {job.name:<{name_width}} {job.submitted_by:<{submitted_width}} {status_display:<{status_width}} {approval_display:<{approval_width}}"
             lines.append(line)
             job_index += 1
 
@@ -1242,6 +1249,7 @@ def jobs_list_repr_html(jobs: List["JobInfo"], root_email: str) -> str:
                             <th class="syftjob-th">Job Name</th>
                             <th class="syftjob-th">Submitted By</th>
                             <th class="syftjob-th">Status</th>
+                            <th class="syftjob-th">Approval</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -1251,6 +1259,7 @@ def jobs_list_repr_html(jobs: List["JobInfo"], root_email: str) -> str:
             style_info = status_styles.get(job.status, {"emoji": "❓"})
             row_class = "syftjob-row-even" if i % 2 == 0 else "syftjob-row-odd"
 
+            approval_display = job.approval_method or "—"
             html += f"""
                         <tr class="{row_class} syftjob-row">
                             <td class="syftjob-td">
@@ -1266,6 +1275,9 @@ def jobs_list_repr_html(jobs: List["JobInfo"], root_email: str) -> str:
                                 <span class="syftjob-status-{job.status}">
                                     {style_info["emoji"]} {job.status.upper()}
                                 </span>
+                            </td>
+                            <td class="syftjob-td">
+                                {approval_display}
                             </td>
                         </tr>
                 """

--- a/packages/syft-job/src/syft_job/models/state.py
+++ b/packages/syft-job/src/syft_job/models/state.py
@@ -30,6 +30,7 @@ class JobState(BaseModel):
     # Local job approval
     approved_by: Optional[str] = None
     approved_at: Optional[datetime] = None
+    approval_method: Optional[str] = None  # "manual" or "auto"
 
     # Rejection
     rejected_by: Optional[str] = None

--- a/syft_client/job_auto_approval.py
+++ b/syft_client/job_auto_approval.py
@@ -208,7 +208,7 @@ def auto_approve_and_run_jobs(
             approved_peers=approved_peers,
         ):
             try:
-                job.approve()
+                job.approve(approval_method="auto")
                 approved_jobs.append(job)
 
                 if on_approve is not None:


### PR DESCRIPTION
## Summary
- Add `approval_method` field (`"manual"` or `"auto"`) to `JobState`, propagated via `state.yaml` so DS can check `job.approval_method` after sync
- All auto-approval paths (DS-side `auto_approve_and_run_jobs`, DO-side `JobApprovalHandler`, email `auto-approve` reply) now set `approval_method="auto"`
- Manual approvals (default `job.approve()`) set `approval_method="manual"`
- Updated text, `__repr__`, and HTML repr to display the approval method in job views

## Test plan
- [x] All 293 unit tests pass
- [ ] Verify in e2e notebook: manually approved job shows `manual`, auto-approved job shows `auto`
- [ ] Verify older jobs without the field show `None`/`—` gracefully