### PR TITLE
feat: improve UX for login, submit_python_job, and job.approve()

### DIFF
--- a/packages/syft-job/src/syft_job/job.py
+++ b/packages/syft-job/src/syft_job/job.py
@@ -185,7 +185,10 @@ class JobInfo:
         self._state.approved_at = datetime.now(timezone.utc)
         self._state.approval_method = approval_method
         self._state.save(self.job_review_path / "state.yaml")
-        print(f"Job '{self.name}' approved successfully!")
+        print(f"✅ Job '{self.name}' approved successfully!")
+        print("   Status    : approved → will run on next process cycle")
+        print("\n⏳ Next step: run process_approved_jobs() to execute it.")
+        print("   client.process_approved_jobs(share_outputs_with_submitter=True)")
 
     def reject(self, reason: str = "") -> None:
         """

--- a/syft_client/sync/login.py
+++ b/syft_client/sync/login.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from syft_client.sync.utils.syftbox_utils import check_env
 from syft_client.sync.environments.environment import Environment
 from syft_client.sync.syftbox_manager import SyftboxManager
-from syft_client.sync.utils.print_utils import print_client_connected
+from syft_client.sync.utils.print_utils import (
+    print_client_connected,
+    print_client_connecting,
+)
 from syft_client.sync.utils.syftbox_utils import get_email_colab
 from syft_client.sync.config.config import settings
 from syft_client.sync.login_utils import handle_potential_version_mismatches_on_login
@@ -13,6 +16,7 @@ def _init_client_login(
     client: SyftboxManager, sync: bool, load_peers: bool
 ) -> SyftboxManager:
     """Common post-creation initialization: write version, sync, load peers."""
+    print_client_connecting(client.email)
     client.write_local_version()
 
     if sync:

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -803,8 +803,8 @@ class SyftboxManager(BaseModel):
         sync=True,
         force_submission: bool = False,
     ):
-        approved_emails = {p.email for p in self.peer_manager.approved_peers}
-        if user not in approved_emails:
+        peer_emails = {p.email for p in self.peer_manager.syncable_peers}
+        if user not in peer_emails:
             print(f"⚠️  {user} is not in your peer list.")
             print(f"   Add them first with: client.add_peer('{user}')")
             return

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -803,6 +803,18 @@ class SyftboxManager(BaseModel):
         sync=True,
         force_submission: bool = False,
     ):
+        approved_emails = {p.email for p in self.peer_manager.approved_peers}
+        if user not in approved_emails:
+            print(f"⚠️  {user} is not in your peer list.")
+            print(f"   Add them first with: client.add_peer('{user}')")
+            return
+
+        print(f"📤 Submitting '{code_path}' to {user}...")
+        if job_name:
+            print(f"   Job name     : {job_name}")
+        if dependencies:
+            print(f"   Dependencies : {', '.join(dependencies)}")
+
         # Check version compatibility before submission (uses cached versions)
         if not force_submission:
             self.peer_manager.check_version_for_submission(user, force=False)
@@ -814,7 +826,11 @@ class SyftboxManager(BaseModel):
             entrypoint=entrypoint,
         )
         self.push_job_files(job_dir)
-        print(f"Submitted python job, job files are in {job_dir}")
+
+        print("\n✅ Job submitted successfully!")
+        print("   Status : inbox (waiting for DO to review)")
+        print(f"\n⏳ Next step: wait for {user} to approve and run it.")
+        print("   Check progress with: client.jobs")
 
     def push_job_files(self, job_dir: Path):
         file_paths = [Path(p) for p in job_dir.rglob("*") if p.is_file()]

--- a/syft_client/sync/utils/print_utils.py
+++ b/syft_client/sync/utils/print_utils.py
@@ -1,4 +1,7 @@
 from syft_client.sync.peers.peer import Peer
+from syft_client.sync.utils.syftbox_utils import check_env
+from syft_client.sync.environments.environment import Environment
+from syft_client.version import SYFT_CLIENT_VERSION
 from typing import TYPE_CHECKING
 
 
@@ -6,15 +9,24 @@ if TYPE_CHECKING:
     from syft_client.sync.syftbox_manager import SyftboxManager
 
 
+def print_client_connecting(email: str):
+    is_colab = check_env() == Environment.COLAB
+    print(f"🔑 Logging in as {email}...")
+    print(f"   Environment: {'Colab' if is_colab else 'Python'}")
+
+
 def print_client_connected(client: "SyftboxManager"):
-    platforms_str = ", ".join(
-        [platform.name for platform in client._get_all_peer_platforms()]
-    )
-    n_peers = len(client.peers)
-    if n_peers > 0:
-        print(f"✅ Connected peer-to-peer to {n_peers} peers via: {platforms_str}")
+    print("\n✅ Logged in successfully!")
+    print(f"   SyftBox folder : {client.syftbox_folder}")
+    print(f"   Version        : {SYFT_CLIENT_VERSION}")
+
+    peers = client.peer_manager.approved_peers
+    if peers:
+        print(f"\n👥 {len(peers)} peer(s) restored from previous session.")
+        print("   Run client.sync() to pull the latest updates.")
     else:
-        print(f"✅ Connected to {n_peers} peers")
+        print("\n💡 No peers yet. Add a Data Owner with:")
+        print("   client.add_peer('do@org.com')")
 
 
 def print_peer_adding_to_platform(peer_email: str, platform_str: str):


### PR DESCRIPTION
- `submit_python_job`: echo params before submit, print success block with `inbox` status + next-step pointer to `client.jobs`, warn early when target user is not an approved peer
- `job.approve()`: keep success line and add status transition + next-step hint to call `process_approved_jobs()`
- Login flow: split `print_client_connecting` (env line, called at start of `_init_client_login`) from `print_client_connected` (success block with SyftBox folder, version, and peers/no-peers hint)