### PR TITLE
feat: pre-submit anti-pattern scan for submit_python_job

### DIFF
--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -34,6 +34,7 @@ from syft_client.sync.events.file_change_event import (
     FileChangeEvent,
     FileChangeEventsMessage,
 )
+from syft_client.sync.utils.pre_submit_scan import run_pre_submit_check
 from syft_client.sync.utils.syftbox_utils import (
     random_email,
     random_syftbox_folder_for_testing,
@@ -808,6 +809,11 @@ class SyftboxManager(BaseModel):
             print(f"⚠️  {user} is not in your peer list.")
             print(f"   Add them first with: client.add_peer('{user}')")
             return
+
+        if not force_submission:
+            if not run_pre_submit_check(Path(code_path)):
+                print("Submission aborted.")
+                return
 
         print(f"📤 Submitting '{code_path}' to {user}...")
         if job_name:

--- a/syft_client/sync/utils/pre_submit_scan.py
+++ b/syft_client/sync/utils/pre_submit_scan.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+_RESOLVER_NAMES = {"resolve_dataset_files_path", "resolve_dataset_file_path"}
+_CLIENT_KWARG_FALLBACK_RE = re.compile(
+    r"resolve_dataset_files?_path\s*\([^)]*\bclient\s*=", re.DOTALL
+)
+_DATASET_FILES_ATTR_RE = re.compile(r"\.(mock_files|private_files)\b")
+
+
+def run_pre_submit_check(code_path: Path) -> bool:
+    """Scan job code for known anti-patterns. Return True if submission should proceed."""
+    py_files = _collect_py_files(code_path)
+
+    found_client_kwarg = any(_has_client_kwarg(f) for f in py_files)
+    found_dataset_attr = any(_has_dataset_files_attr(f) for f in py_files)
+
+    if found_client_kwarg:
+        _print_client_kwarg_warning()
+        return _confirm_continue()
+
+    if found_dataset_attr:
+        _print_dataset_files_warning()
+        return _confirm_continue()
+
+    print("✅ Pre-submit check passed.")
+    return True
+
+
+def _collect_py_files(code_path: Path) -> list[Path]:
+    p = Path(code_path)
+    if not p.exists():
+        return []
+    if p.is_file():
+        return [p] if p.suffix == ".py" else []
+    return sorted(p.rglob("*.py"))
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text()
+    except Exception:
+        return None
+
+
+def find_client_kwarg_in_ast(tree: ast.AST) -> bool:
+    """Return True if the AST contains a resolver call with a `client=` kwarg."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func_name: str | None = None
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            func_name = node.func.attr
+        if func_name not in _RESOLVER_NAMES:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "client":
+                return True
+    return False
+
+
+def _has_client_kwarg(path: Path) -> bool:
+    content = _read(path)
+    if content is None:
+        return False
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return bool(_CLIENT_KWARG_FALLBACK_RE.search(content))
+    return find_client_kwarg_in_ast(tree)
+
+
+def _has_dataset_files_attr(path: Path) -> bool:
+    content = _read(path)
+    if content is None:
+        return False
+    return bool(_DATASET_FILES_ATTR_RE.search(content))
+
+
+def _print_client_kwarg_warning() -> None:
+    print(
+        "🚨 Pre-submit check failed:\n\n"
+        "   Your script contains 'client=client' which will fail on the DO's machine.\n"
+        "   'client' is not defined there — it is only available in your local Colab session.\n\n"
+        "   Fix: remove 'client=client' from resolve_dataset_files_path() and re-run %%writefile.\n\n"
+        "   ✅ Correct:  sc.resolve_dataset_files_path('beach_water_quality')\n"
+        "   ❌ Wrong:    sc.resolve_dataset_files_path('beach_water_quality', client=client)"
+    )
+
+
+def _print_dataset_files_warning() -> None:
+    print(
+        "🚨 Pre-submit check failed:\n\n"
+        "   Your script references '.mock_files' or '.private_files' on a Dataset object,\n"
+        "   which won't exist on the DO's machine — those attributes belong to a Dataset\n"
+        "   you constructed locally.\n\n"
+        "   Fix: replace dataset.mock_files / dataset.private_files with\n"
+        "        sc.resolve_dataset_files_path('<dataset_name>') and re-run %%writefile.\n\n"
+        "   ✅ Correct:  sc.resolve_dataset_files_path('beach_water_quality')\n"
+        "   ❌ Wrong:    dataset.mock_files  /  dataset.private_files"
+    )
+
+
+def _confirm_continue() -> bool:
+    if not sys.stdin.isatty():
+        print("(non-interactive environment; continuing without prompt)")
+        return True
+    print("\nContinue with submission anyway? (y/N): ", end="", flush=True)
+    return input().strip().lower() in ("y", "yes")

--- a/tests/unit/test_pre_submit_scan.py
+++ b/tests/unit/test_pre_submit_scan.py
@@ -1,0 +1,155 @@
+"""Tests for the pre-submit script scanner."""
+
+import ast
+
+import pytest
+
+from syft_client.sync.utils.pre_submit_scan import (
+    find_client_kwarg_in_ast,
+    run_pre_submit_check,
+)
+
+
+# --- AST walker tested in isolation ---
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        'sc.resolve_dataset_files_path("foo", client=c)',
+        'resolve_dataset_files_path("foo", client=c)',
+        'resolve_dataset_file_path("foo", client=c)',
+        'sc.resolve_dataset_file_path("foo", owner_email="x", client=c)',
+        # Call buried inside other expressions still detected
+        'x = [sc.resolve_dataset_files_path("foo", client=c) for _ in range(1)]',
+    ],
+)
+def test_find_client_kwarg_in_ast_positive(src):
+    tree = ast.parse(src)
+    assert find_client_kwarg_in_ast(tree) is True
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        'resolve_dataset_files_path("foo", owner_email="x")',
+        'resolve_dataset_files_path("foo")',
+        'sc.resolve_dataset_files_path("foo")',
+        # Function definition, not a Call
+        "def foo(client=client): pass",
+        # Plain assignment
+        "client = client",
+        # Unrelated function with the same kwarg
+        'some_other_func("foo", client=c)',
+    ],
+)
+def test_find_client_kwarg_in_ast_negative(src):
+    tree = ast.parse(src)
+    assert find_client_kwarg_in_ast(tree) is False
+
+
+# --- Full scanner via run_pre_submit_check ---
+
+
+def _write_script(tmp_path, name, content):
+    path = tmp_path / name
+    path.write_text(content)
+    return path
+
+
+def test_run_pre_submit_check_clean_script(tmp_path, capsys):
+    script = _write_script(
+        tmp_path,
+        "main.py",
+        'import syft_client as sc\nsc.resolve_dataset_files_path("foo")\n',
+    )
+    assert run_pre_submit_check(script) is True
+    out = capsys.readouterr().out
+    assert "✅ Pre-submit check passed." in out
+
+
+def test_run_pre_submit_check_client_kwarg(tmp_path, capsys):
+    script = _write_script(
+        tmp_path,
+        "main.py",
+        'import syft_client as sc\nsc.resolve_dataset_files_path("ds", client=client)\n',
+    )
+    # Non-TTY in pytest → continues without prompt
+    assert run_pre_submit_check(script) is True
+    out = capsys.readouterr().out
+    assert "🚨 Pre-submit check failed" in out
+    assert "client=client" in out
+    assert "non-interactive" in out
+
+
+def test_run_pre_submit_check_dataset_files_attr(tmp_path, capsys):
+    script = _write_script(
+        tmp_path,
+        "main.py",
+        "data = dataset.mock_files\n",
+    )
+    assert run_pre_submit_check(script) is True
+    out = capsys.readouterr().out
+    assert "🚨 Pre-submit check failed" in out
+    assert ".mock_files" in out
+
+
+def test_run_pre_submit_check_private_files_attr(tmp_path, capsys):
+    script = _write_script(
+        tmp_path,
+        "main.py",
+        "data = dataset.private_files\n",
+    )
+    assert run_pre_submit_check(script) is True
+    out = capsys.readouterr().out
+    assert "🚨 Pre-submit check failed" in out
+    assert ".mock_files" in out  # warning copy lists both
+
+
+def test_client_kwarg_takes_priority_over_dataset_files(tmp_path, capsys):
+    _write_script(
+        tmp_path,
+        "a.py",
+        'sc.resolve_dataset_files_path("ds", client=client)\n',
+    )
+    _write_script(
+        tmp_path,
+        "b.py",
+        "data = dataset.mock_files\n",
+    )
+    assert run_pre_submit_check(tmp_path) is True
+    out = capsys.readouterr().out
+    assert "client=client" in out
+    # The dataset-files-specific warning copy should NOT appear when client= fires
+    assert "Your script references" not in out
+
+
+def test_syntax_error_falls_back_to_regex(tmp_path, capsys):
+    # Trailing unmatched paren makes ast.parse raise SyntaxError
+    script = _write_script(
+        tmp_path,
+        "broken.py",
+        'sc.resolve_dataset_files_path("ds", client=client\n# unterminated\n',
+    )
+    assert run_pre_submit_check(script) is True
+    out = capsys.readouterr().out
+    assert "🚨 Pre-submit check failed" in out
+    assert "client=client" in out
+
+
+def test_folder_walks_all_py_files(tmp_path, capsys):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    _write_script(tmp_path, "main.py", "x = 1\n")
+    _write_script(sub, "helper.py", "data = obj.mock_files\n")
+    assert run_pre_submit_check(tmp_path) is True
+    out = capsys.readouterr().out
+    assert "🚨 Pre-submit check failed" in out
+
+
+def test_nonexistent_path_passes_silently(tmp_path, capsys):
+    # No .py files → nothing to warn about → passes
+    missing = tmp_path / "does_not_exist"
+    assert run_pre_submit_check(missing) is True
+    out = capsys.readouterr().out
+    assert "✅ Pre-submit check passed." in out


### PR DESCRIPTION
- Scans submitted Python code before sending to the DO and warns on two Colab anti-patterns: `resolve_dataset_files_path(..., client=...)` (AST walk + regex fallback) and `.mock_files` / `.private_files` attribute access (regex)
- Each warning shows a clear `✅ Correct` vs `❌ Wrong` example and prompts `(y/N)` to continue
- Lives in `syft_client/sync/utils/pre_submit_scan.py`; AST walker (`find_client_kwarg_in_ast`) is exported and tested separately from the file-level scanner
- Skipped under `force_submission=True`; non-TTY environments auto-continue so tests/CI don't hang on `input()`