### PR TITLE
feat: friendlier datasets.get error and .mock_files hint in dataset repr

### DIFF
--- a/packages/syft-datasets/src/syft_datasets/dataset.py
+++ b/packages/syft-datasets/src/syft_datasets/dataset.py
@@ -226,7 +226,12 @@ class Dataset(DatasetBase, PydanticFormatterMixin):
             display_paths=paths_to_include,
         )
 
-        return description
+        hint = (
+            '<div style="margin-top: 8px; font-size: 0.9em; color: #666;">'
+            "💡 Use <code>.mock_files</code> to access mock data"
+            "</div>"
+        )
+        return description + hint
 
     def describe(self) -> None:
         from IPython.display import HTML, display

--- a/packages/syft-datasets/src/syft_datasets/dataset_manager.py
+++ b/packages/syft-datasets/src/syft_datasets/dataset_manager.py
@@ -307,7 +307,22 @@ class SyftDatasetManager:
         )
 
         if not mock_dir.exists():
-            raise FileNotFoundError(f"Dataset {name} not found in {mock_dir}")
+            available = self.get_all()
+            if available:
+                listing = "\n".join(
+                    f"   • {d.name} (from {d.owner})" for d in available
+                )
+            else:
+                listing = "   (none found — check your peer connections)"
+            raise FileNotFoundError(
+                f"❌ Dataset '{name}' not found in {datasite}'s datasite.\n\n"
+                f"   Possible reasons:\n"
+                f"   1. The DO hasn't created this dataset yet.\n"
+                f"   2. You're not connected to them as a peer.\n"
+                f"   3. You need to sync first — try: client.sync()\n\n"
+                f"   Available datasets:\n"
+                f"{listing}"
+            )
         return self._load_dataset_from_dir(mock_dir)
 
     def __getitem__(self, key: str | int) -> Dataset:

--- a/tests/unit/test_datasets_jobs_repr.py
+++ b/tests/unit/test_datasets_jobs_repr.py
@@ -69,6 +69,34 @@ def test_dataset_manager_repr_html():
     assert html is not None
 
 
+def test_dataset_manager_get_missing_lists_available():
+    _, do_manager, _ = _create_manager_with_dataset()
+    with pytest.raises(FileNotFoundError) as excinfo:
+        do_manager.datasets.get("nope")
+    msg = str(excinfo.value)
+    assert "❌" in msg
+    assert "'nope'" in msg
+    assert "client.sync()" in msg
+    assert "Available datasets:" in msg
+    assert "test-dataset" in msg
+
+
+def test_dataset_manager_get_missing_no_datasets():
+    _, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+        use_in_memory_cache=False,
+        sync_automatically=False,
+    )
+    with pytest.raises(FileNotFoundError) as excinfo:
+        do_manager.datasets.get("nope")
+    assert "(none found — check your peer connections)" in str(excinfo.value)
+
+
+def test_dataset_repr_html_mentions_mock_files():
+    _, _, dataset = _create_manager_with_dataset()
+    html = dataset._repr_html_()
+    assert ".mock_files" in html
+
+
 # --- JobsList tests ---
 
 


### PR DESCRIPTION
- `client.datasets.get(name)` now raises a friendly `FileNotFoundError` listing likely causes (DO not created, no peer connection, needs sync) plus the currently visible datasets — falls back to `(none found — check your peer connections)` when nothing is visible.
- Dataset HTML repr (notebook display) now ends with a hint: `💡 Use .mock_files to access mock data`.
- Three new unit tests in `tests/unit/test_datasets_jobs_repr.py` cover both error paths and the repr hint.