### PR TITLE
feat: add manual e2e testing notebook

### DIFF
--- a/notebooks/beach/internal/test_manual_e2e.ipynb
+++ b/notebooks/beach/internal/test_manual_e2e.ipynb
@@ -1,0 +1,697 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SyftBox Manual E2E Test\n",
+    "\n",
+    "This notebook walks through a complete end-to-end workflow between a **Data Owner (DO)** and a **Data Scientist (DS)** using SyftBox. It demonstrates dataset creation, browsing, job submission, code review, approval/rejection, execution, and result retrieval.\n",
+    "\n",
+    "### Flow Overview\n",
+    "\n",
+    "1. **Setup** — Configuration, authentication, and peer connection\n",
+    "2. **Data Owner** — Creates and publishes datasets\n",
+    "3. **Data Scientist** — Browses datasets, prototypes code on mock data, submits two jobs\n",
+    "4. **Data Owner** — Reviews submitted code, approves one job, rejects the other, and runs the approved job\n",
+    "5. **Data Scientist** — Retrieves the output of the approved job and the rejection reason for the other\n",
+    "\n",
+    "### Prerequisites\n",
+    "- GCP project with **Google Drive API** enabled\n",
+    "- OAuth credentials JSON (`app_credentials.json`)\n",
+    "- DS token (`token_ds.json`)\n",
+    "- A `.env` file with: `DO_EMAIL`, `DS_EMAIL`, `GCP_PROJECT_ID`, `APP_CREDENTIALS`, `TOKEN_DS`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.1 Configuration\n",
+    "\n",
+    "Load environment variables and validate that credential files exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Load .env file\n",
+    "for line in Path(\".env\").read_text().splitlines():\n",
+    "    if line.strip() and not line.startswith(\"#\"):\n",
+    "        key, _, value = line.partition(\"=\")\n",
+    "        os.environ.setdefault(key.strip(), value.strip())\n",
+    "\n",
+    "DO_EMAIL = os.environ[\"DO_EMAIL\"]\n",
+    "DS_EMAIL = os.environ[\"DS_EMAIL\"]\n",
+    "GCP_PROJECT_ID = os.environ[\"GCP_PROJECT_ID\"]\n",
+    "\n",
+    "APP_CREDENTIALS = Path(os.environ[\"APP_CREDENTIALS\"])\n",
+    "TOKEN_DS = Path(os.environ[\"TOKEN_DS\"])\n",
+    "\n",
+    "assert APP_CREDENTIALS.exists(), \"App credentials missing\"\n",
+    "assert TOKEN_DS.exists(), \"DS credentials missing\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Create DO token (one-time)\n",
+    "\n",
+    "Converts OAuth app credentials to a user-authorized Drive token.\n",
+    "Uncomment and run once — it will open a browser window for authorization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft_client as sc\n",
+    "\n",
+    "do_token_path = str(APP_CREDENTIALS.parent / \"token_do_email_test.json\")\n",
+    "# do_token_path = sc.credentials_to_token(\n",
+    "#     credentials_path=str(APP_CREDENTIALS),\n",
+    "#     output_path=do_token_path,\n",
+    "#     do_scopes=True\n",
+    "# )\n",
+    "# print(f\"DO token saved to: {do_token_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3 Login\n",
+    "\n",
+    "Log in as both the Data Owner and the Data Scientist. Each client maintains its own local SyftBox folder and syncs independently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client = sc.login_do(email=DO_EMAIL, token_path=str(do_token_path))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_client = sc.login_ds(email=DS_EMAIL, token_path=str(TOKEN_DS))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.4 Optional — Wipe prior state\n",
+    "\n",
+    "Uncomment to delete all local SyftBox data and start fresh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# do_client.delete_syftbox()\n",
+    "# ds_client.delete_syftbox()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.5 Establish peer connection\n",
+    "\n",
+    "The Data Scientist requests access to the Data Owner, and the Data Owner approves. This is required before any data or jobs can be exchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_client.add_peer(DO_EMAIL)\n",
+    "\n",
+    "do_client.load_peers()\n",
+    "do_client.approve_peer_request(DS_EMAIL, peer_must_exist=False)\n",
+    "\n",
+    "print(\"Peer relationship established\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Data Owner: Create Datasets\n",
+    "\n",
+    "The Data Owner creates datasets that will be shared with the Data Scientist. Each dataset has:\n",
+    "- **Mock data** — a public, non-sensitive version that the DS can freely access and prototype against\n",
+    "- **Private data** — the real data that never leaves the DO's machine; only job code can access it at runtime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Create a simple text dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.create_dataset(\n",
+    "    name=\"testdata\",\n",
+    "    mock_path=\"data/mock.txt\",\n",
+    "    private_path=\"data/private.txt\",\n",
+    "    users=[DS_EMAIL],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Create a PDF dataset\n",
+    "\n",
+    "Generate sample PDFs, then create a dataset with a CSV manifest as mock data and the PDFs as private data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv run create_test_pdfs.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.create_dataset(\n",
+    "    name=\"pdfdata\",\n",
+    "    mock_path=\"data/manifest.csv\",\n",
+    "    private_path=\"data/PDFs\",\n",
+    "    summary=\"A dataset with some PDFs\",\n",
+    "    readme_path=\"data/readme.md\",\n",
+    "    tags=[\"test\", \"pdf\"],\n",
+    "    users=[DS_EMAIL],\n",
+    "    upload_private=False,\n",
+    "    sync=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 View datasets\n",
+    "\n",
+    "The Data Owner can list all their datasets and inspect individual ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = do_client.datasets.get(\"testdata\", datasite=DO_EMAIL)\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mock_contents = dataset.mock_files[0].read_text()\n",
+    "print(f\"Mock file contents: {mock_contents!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Data Scientist: Browse Datasets and Prototype Code\n",
+    "\n",
+    "The Data Scientist syncs to discover available datasets. They can only see mock data — the private data stays on the Data Owner's machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1 List available datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_client.datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Write trial code against mock data\n",
+    "\n",
+    "Before submitting a job, the Data Scientist can prototype their analysis locally using the mock data. The `resolve_dataset_file_path` function returns mock data when run locally, and private data when run as a job on the DO's machine.\n",
+    "\n",
+    "> **Note:** Remove the `client=` parameter before submitting as a job — it will resolve automatically on the DO's machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft_client as sc\n",
+    "import pandas as pd\n",
+    "\n",
+    "resolved_path = sc.resolve_dataset_file_path(\"testdata\", client=ds_client)\n",
+    "df = pd.read_fwf(resolved_path)\n",
+    "print(f\"Type of data in use: {df.columns[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Submit jobs\n",
+    "\n",
+    "Now the Data Scientist submits two different jobs to the Data Owner. Each job is a self-contained Python script that will run in an isolated environment on the DO's machine.\n",
+    "\n",
+    "- **Job A** (`summary_stats`) — computes basic statistics on the dataset\n",
+    "- **Job B** (`column_names`) — extracts and returns column names from the dataset\n",
+    "\n",
+    "Both jobs use `resolve_dataset_file_path` to access the private data at runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "def write_job_script(code: str) -> str:\n",
+    "    \"\"\"Write a job script to a temp file and return its path.\"\"\"\n",
+    "    job_dir = Path(tempfile.mkdtemp(prefix=\"syft_job_\"))\n",
+    "    script = job_dir / \"main.py\"\n",
+    "    script.write_text(code)\n",
+    "    return str(script)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Job A: Summary Statistics\n",
+    "\n",
+    "A simple analysis job that reads the dataset and computes summary statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "JOB_A_NAME = \"summary_stats\"\n",
+    "\n",
+    "job_a_code = write_job_script('''import os, json\n",
+    "import syft_client as sc\n",
+    "import pandas as pd\n",
+    "\n",
+    "resolved_path = sc.resolve_dataset_file_path(\"testdata\")\n",
+    "df = pd.read_fwf(resolved_path)\n",
+    "\n",
+    "result = {\n",
+    "    \"message\": \"Summary statistics computed successfully\",\n",
+    "    \"row_count\": len(df),\n",
+    "    \"columns\": list(df.columns),\n",
+    "}\n",
+    "\n",
+    "os.makedirs(\"outputs\", exist_ok=True)\n",
+    "with open(\"outputs/result.json\", \"w\") as f:\n",
+    "    json.dump(result, f, indent=2)\n",
+    "\n",
+    "print(f\"Result: {result}\")\n",
+    "''')\n",
+    "\n",
+    "ds_client.submit_python_job(\n",
+    "    user=DO_EMAIL,\n",
+    "    code_path=job_a_code,\n",
+    "    job_name=JOB_A_NAME,\n",
+    "    force_submission=True,\n",
+    "    dependencies=[\"pandas\"],\n",
+    ")\n",
+    "print(f\"Job '{JOB_A_NAME}' submitted to {DO_EMAIL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Job B: Column Names\n",
+    "\n",
+    "This job intentionally leaks column names from the private dataset — the kind of thing a Data Owner might want to reject."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "JOB_B_NAME = \"column_names\"\n",
+    "\n",
+    "job_b_code = write_job_script('''import os, json\n",
+    "import syft_client as sc\n",
+    "import pandas as pd\n",
+    "\n",
+    "resolved_path = sc.resolve_dataset_file_path(\"testdata\")\n",
+    "df = pd.read_fwf(resolved_path)\n",
+    "\n",
+    "# This leaks sensitive column names from the private dataset\n",
+    "result = {\n",
+    "    \"message\": \"Extracted column names\",\n",
+    "    \"column_names\": list(df.columns),\n",
+    "}\n",
+    "\n",
+    "os.makedirs(\"outputs\", exist_ok=True)\n",
+    "with open(\"outputs/result.json\", \"w\") as f:\n",
+    "    json.dump(result, f, indent=2)\n",
+    "\n",
+    "print(f\"Result: {result}\")\n",
+    "''')\n",
+    "\n",
+    "ds_client.submit_python_job(\n",
+    "    user=DO_EMAIL,\n",
+    "    code_path=job_b_code,\n",
+    "    job_name=JOB_B_NAME,\n",
+    "    force_submission=True,\n",
+    "    dependencies=[\"pandas\"],\n",
+    ")\n",
+    "print(f\"Job '{JOB_B_NAME}' submitted to {DO_EMAIL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Data Owner: Review, Approve/Reject, and Run Jobs\n",
+    "\n",
+    "The Data Owner syncs to receive the submitted jobs, reviews the code, and decides whether to approve or reject each one. Approved jobs are then executed on the DO's machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 List incoming jobs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.jobs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Review the submitted code\n",
+    "\n",
+    "Look up each job by name and inspect the code before making a decision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_a = do_client.jobs[JOB_A_NAME]\n",
+    "print(f\"--- {job_a.name} (status: {job_a.status}) ---\")\n",
+    "print(job_a.code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_b = do_client.jobs[JOB_B_NAME]\n",
+    "print(f\"--- {job_b.name} (status: {job_b.status}) ---\")\n",
+    "print(job_b.code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.3 View the full job object\n",
+    "Alternatively, you can view the full job object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.3 Approve Job A, Reject Job B\n",
+    "\n",
+    "The DO approves the summary statistics job and rejects the column names job because it would leak sensitive information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_a.approve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_b.reject(reason=\"The job leaks sensitive column names from the private dataset\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.4 Run approved jobs\n",
+    "\n",
+    "Execute all approved jobs. Each job runs in an isolated Python virtual environment on the DO's machine. The private dataset is accessible to the job code via `resolve_dataset_file_path`. You can pass these arguments: \n",
+    "1. `stream_output`: If True (default), stream output in real-time. If False, capture output at end.\n",
+    "2. `timeout`: Timeout in seconds per job. Defaults to 300 (5 minutes).\n",
+    "3. `force_execution`: If True, process all approved jobs regardless of version compatibility. If False (default), skip jobs from peers with incompatible or unknown versions.\n",
+    "4. `share_outputs_with_submitter`: If True, grant read access on outputs to submitter.\n",
+    "5. `share_logs_with_submitter`: If True, grant read access on logs to submitter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.process_approved_jobs(\n",
+    "    share_outputs_with_submitter=True,\n",
+    "    share_logs_with_submitter=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Data Scientist: Retrieve Results\n",
+    "\n",
+    "The Data Scientist syncs to pull back the job results. They can read the output of the approved job and see the reason for the rejected one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.1 Check job statuses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_client.jobs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Read the output of the approved job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_job_a = ds_client.jobs[JOB_A_NAME]\n",
+    "print(f\"Status: {ds_job_a.status}\")\n",
+    "print(f\"Output files: {ds_job_a.output_paths}\")\n",
+    "\n",
+    "if ds_job_a.output_paths:\n",
+    "    print(f\"\\nResult:\\n{ds_job_a.output_paths[0].read_text()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.3 See the rejection reason for the rejected job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_job_b = ds_client.jobs[JOB_B_NAME]\n",
+    "print(f\"Status: {ds_job_b.status}\")\n",
+    "print(f\"Rejection reason: {ds_job_b._state.rejection_reason}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Cleanup\n",
+    "\n",
+    "Remove generated test files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf data/PDFs data/manifest.csv data/readme.md"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Adds a structured manual E2E test notebook in `notebooks/beach/internal/test_manual_e2e.ipynb`
- Covers the full DO/DS workflow: login, dataset creation, browsing, mock prototyping, two separate job submissions, code review, approve/reject, job execution, and result retrieval

## Test plan
- [x] Run notebook cells top-to-bottom with valid `.env` credentials
- [x] Verify both jobs appear in DO's job list by name
- [x] Confirm Job A output is readable by DS after approval
- [ ] Confirm Job B rejection reason is visible to DS