### PR TITLE
test: add syft-bg integration test notebook

### DIFF
--- a/notebooks/beach/internal/test_syft_bg.ipynb
+++ b/notebooks/beach/internal/test_syft_bg.ipynb
@@ -8,10 +8,10 @@
     "\n",
     "Reusable notebook that tests `syft_bg` service management:\n",
     "\n",
-    "1. **Config & Status basics** \u2014 init, inspect config, check status\n",
-    "2. **Misconfigured `email_approve`** \u2014 missing `gcp_project_id` \u2192 graceful error\n",
-    "3. **Start / Stop / Restart** \u2014 verify PID lifecycle\n",
-    "4. **Auto-approve job via API** \u2014 `auto_approve_job()`, follow-up auto-approval, list/remove rules\n",
+    "1. **Config & Status basics** — init, inspect config, check status\n",
+    "2. **Misconfigured `email_approve`** — missing `gcp_project_id` → graceful error\n",
+    "3. **Start / Stop / Restart** — verify PID lifecycle\n",
+    "4. **Auto-approve job via API** — `auto_approve_job()`, follow-up auto-approval, list/remove rules\n",
     "\n",
     "### Prerequisites\n",
     "- `.env` file with `DO_EMAIL`, `DS_EMAIL`, `GCP_PROJECT_ID`, `APP_CREDENTIALS`, `TOKEN_DS`\n",
@@ -20,13 +20,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -37,10 +37,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": "import os\nfrom pathlib import Path\n\nfor line in Path(\".env\").read_text().splitlines():\n    if line.strip() and not line.startswith(\"#\"):\n        key, _, value = line.partition(\"=\")\n        os.environ.setdefault(key.strip(), value.strip())\n\nDO_EMAIL = os.environ[\"DO_EMAIL\"]\nDS_EMAIL = os.environ[\"DS_EMAIL\"]\nGCP_PROJECT_ID = os.environ[\"GCP_PROJECT_ID\"]\n\nAPP_CREDENTIALS = Path(os.environ[\"APP_CREDENTIALS\"])\nTOKEN_DS = Path(os.environ[\"TOKEN_DS\"])\nDO_CREDENTIALS = Path(\"/Users/bitsofsteve/code/syft-client/creds.stephen.json\")\nDO_TOKEN = Path(\"/Users/bitsofsteve/code/syft-client/notebooks/beach/internal/token_do.json\")\n\nassert APP_CREDENTIALS.exists(), f\"App credentials missing: {APP_CREDENTIALS}\"\nassert DO_CREDENTIALS.exists(), f\"DO credentials missing: {DO_CREDENTIALS}\"\n\nprint(f\"DO: {DO_EMAIL}\")\nprint(f\"DS: {DS_EMAIL}\")",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "for line in Path(\".env\").read_text().splitlines():\n",
+    "    if line.strip() and not line.startswith(\"#\"):\n",
+    "        key, _, value = line.partition(\"=\")\n",
+    "        os.environ.setdefault(key.strip(), value.strip())\n",
+    "\n",
+    "DO_EMAIL = os.environ[\"DO_EMAIL\"]\n",
+    "DS_EMAIL = os.environ[\"DS_EMAIL\"]\n",
+    "GCP_PROJECT_ID = os.environ[\"GCP_PROJECT_ID\"]\n",
+    "\n",
+    "APP_CREDENTIALS = Path(os.environ[\"APP_CREDENTIALS\"])\n",
+    "TOKEN_DS = Path(os.environ[\"TOKEN_DS\"])\n",
+    "DO_CREDENTIALS = Path(\"/Users/bitsofsteve/code/syft-client/creds.stephen.json\")\n",
+    "DO_TOKEN = Path(\"/Users/bitsofsteve/code/syft-client/notebooks/beach/internal/token_do.json\")\n",
+    "\n",
+    "assert APP_CREDENTIALS.exists(), f\"App credentials missing: {APP_CREDENTIALS}\"\n",
+    "assert DO_CREDENTIALS.exists(), f\"DO credentials missing: {DO_CREDENTIALS}\"\n",
+    "\n",
+    "print(f\"DO: {DO_EMAIL}\")\n",
+    "print(f\"DS: {DS_EMAIL}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -53,7 +76,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import syft_client as sc\n",
     "\n",
@@ -63,23 +88,33 @@
     "#     output_path=str(TOKEN_DS),\n",
     "# )\n",
     "# print(f\"DS token saved to: {TOKEN_DS}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": "# --- DO token (Drive + Gmail + PubSub scopes) ---\n# sc.credentials_to_token(\n#     credentials_path=str(DO_CREDENTIALS),\n#     output_path=str(DO_TOKEN),\n#     do_scopes=True,\n# )\n# print(f\"DO token saved to: {DO_TOKEN}\")",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "# --- DO token (Drive + Gmail + PubSub scopes) ---\n",
+    "# sc.credentials_to_token(\n",
+    "#     credentials_path=str(DO_CREDENTIALS),\n",
+    "#     output_path=str(DO_TOKEN),\n",
+    "#     do_scopes=True,\n",
+    "# )\n",
+    "# print(f\"DO token saved to: {DO_TOKEN}\")"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": "assert TOKEN_DS.exists(), f\"DS token missing: {TOKEN_DS} \u2014 uncomment generation cell above\"\nassert DO_TOKEN.exists(), f\"DO token missing: {DO_TOKEN} \u2014 uncomment generation cell above\"\nprint(\"All tokens ready\")",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "assert TOKEN_DS.exists(), f\"DS token missing: {TOKEN_DS} — uncomment generation cell above\"\n",
+    "assert DO_TOKEN.exists(), f\"DO token missing: {DO_TOKEN} — uncomment generation cell above\"\n",
+    "print(\"All tokens ready\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -90,27 +125,27 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import syft_client as sc\n",
     "\n",
     "do_client = sc.login_do(email=DO_EMAIL, token_path=str(DO_TOKEN))\n",
     "ds_client = sc.login_ds(email=DS_EMAIL, token_path=str(TOKEN_DS))"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "ds_client.add_peer(DO_EMAIL)\n",
     "do_client.load_peers()\n",
     "do_client.approve_peer_request(DS_EMAIL, peer_must_exist=False)\n",
     "print(\"Peer relationship established\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -121,10 +156,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": "try:\n    do_client.create_dataset(\n        name=\"testdata\",\n        mock_path=\"data/mock.txt\",\n        private_path=\"data/private.txt\",\n        users=[DS_EMAIL],\n    )\nexcept FileExistsError:\n    print(\"Dataset 'testdata' already exists, skipping creation\")",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "try:\n",
+    "    do_client.create_dataset(\n",
+    "        name=\"testdata\",\n",
+    "        mock_path=\"data/mock.txt\",\n",
+    "        private_path=\"data/private.txt\",\n",
+    "        users=[DS_EMAIL],\n",
+    "    )\n",
+    "except FileExistsError:\n",
+    "    print(\"Dataset 'testdata' already exists, skipping creation\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -136,18 +181,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import syft_bg\n",
     "\n",
     "syft_bg.reset()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "syft_bg.init(\n",
     "    do_email=DO_EMAIL,\n",
@@ -156,34 +203,32 @@
     "        \"email_approve\": {\"gcp_project_id\": GCP_PROJECT_ID},\n",
     "    },\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Inspect config \u2014 should show do_email, token paths, and gcp_project_id\n",
+    "# Inspect config — should show do_email, token paths, and gcp_project_id\n",
     "syft_bg.config"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Status before starting any services \u2014 all should be stopped\n",
+    "# Status before starting any services — all should be stopped\n",
     "status = syft_bg.status\n",
     "print(status)\n",
     "\n",
     "for name, info in status.service_infos.items():\n",
     "    assert info.status.value in (\"stopped\", \"unknown\"), f\"{name} should be stopped, got {info.status}\"\n",
     "print(\"\\nAll services stopped as expected\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -195,7 +240,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Re-init WITHOUT gcp_project_id for email_approve\n",
     "syft_bg.reset()\n",
@@ -204,28 +251,28 @@
     "    token_path=str(DO_TOKEN),\n",
     "    # intentionally no email_approve settings\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import time\n",
     "\n",
-    "# Start only email_approve \u2014 it should fail during setup\n",
+    "# Start only email_approve — it should fail during setup\n",
     "syft_bg.ensure_running(services=[\"email_approve\"])\n",
     "\n",
     "# Give the subprocess time to attempt setup and write error state\n",
     "time.sleep(5)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from syft_bg.services.base import ServiceStatus\n",
     "\n",
@@ -238,13 +285,13 @@
     ")\n",
     "print(f\"\\nemail_approve correctly in ERROR state\")\n",
     "print(f\"Error: {ea_info.error[:200] if ea_info.error else 'no error message'}...\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Check logs confirm the gcp_project_id error\n",
     "log_lines = syft_bg.logs(\"email_approve\", n=30, as_list=True)\n",
@@ -253,9 +300,7 @@
     "print(\"Logs confirm missing gcp_project_id:\")\n",
     "for line in error_lines:\n",
     "    print(f\"  {line}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -267,7 +312,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Clean slate with proper config\n",
     "syft_bg.reset()\n",
@@ -278,20 +325,33 @@
     "        \"email_approve\": {\"gcp_project_id\": GCP_PROJECT_ID},\n",
     "    },\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": "# Start sync, notify, approve (skip email_approve \u2014 it needs Pub/Sub infra)\n# Start sync first so it creates the cache directory before approve needs it\nSERVICES = [\"sync\", \"notify\", \"approve\"]\n\nsyft_bg.ensure_running(services=[\"sync\"], restart=True)\ntime.sleep(10)  # let sync create .cache dir\n\nsyft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\ntime.sleep(5)\n\nstatus = syft_bg.status\nprint(status)",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "# Start sync, notify, approve (skip email_approve — it needs Pub/Sub infra)\n",
+    "# Start sync first so it creates the cache directory before approve needs it\n",
+    "SERVICES = [\"sync\", \"notify\", \"approve\"]\n",
+    "\n",
+    "syft_bg.ensure_running(services=[\"sync\"], restart=True)\n",
+    "time.sleep(10)  # let sync create .cache dir\n",
+    "\n",
+    "syft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\n",
+    "time.sleep(5)\n",
+    "\n",
+    "status = syft_bg.status\n",
+    "print(status)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Record initial PIDs\n",
     "initial_pids = {}\n",
@@ -304,15 +364,15 @@
     "    print(f\"{svc}: PID {info.pid} ({info.status.value})\")\n",
     "\n",
     "print(f\"\\nAll {len(SERVICES)} services running\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Restart the approve service \u2014 PID should change\n",
+    "# Restart the approve service — PID should change\n",
     "syft_bg.restart(\"approve\")\n",
     "time.sleep(3)\n",
     "\n",
@@ -322,13 +382,13 @@
     "    f\"approve PID should have changed: was {initial_pids['approve']}, still {new_approve_info.pid}\"\n",
     ")\n",
     "print(f\"approve restarted: PID {initial_pids['approve']} -> {new_approve_info.pid}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Stop approve\n",
     "syft_bg.stop(\"approve\")\n",
@@ -346,13 +406,13 @@
     "        f\"{svc} should still be running\"\n",
     "    )\n",
     "print(\"sync and notify still running\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Start approve again\n",
     "syft_bg.start(\"approve\")\n",
@@ -364,9 +424,7 @@
     ")\n",
     "print(f\"approve running again: PID {restarted_status.service_infos['approve'].pid}\")\n",
     "print(\"\\nStart/Stop/Restart test passed\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -382,7 +440,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import json\n",
     "import tempfile\n",
@@ -405,16 +465,21 @@
     "    )\n",
     "    (project_dir / \"params.json\").write_text(json.dumps(params))\n",
     "    return project_dir"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": "# Ensure services are running for this test\nsyft_bg.ensure_running(services=[\"sync\"], restart=True)\ntime.sleep(10)\nsyft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\ntime.sleep(5)\nprint(syft_bg.status)",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "# Ensure services are running for this test\n",
+    "syft_bg.ensure_running(services=[\"sync\"], restart=True)\n",
+    "time.sleep(10)\n",
+    "syft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\n",
+    "time.sleep(5)\n",
+    "print(syft_bg.status)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -425,7 +490,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "JOB_NAME = f\"api_auto_{uuid.uuid4().hex[:8]}\"\n",
     "job_dir = create_parameterized_job(main_file=\"main.py\", params={\"run\": 1})\n",
@@ -438,13 +505,13 @@
     "    force_submission=True,\n",
     ")\n",
     "print(f\"Submitted: {JOB_NAME}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Wait for sync service to make the job visible on DO side\n",
     "for attempt in range(12):\n",
@@ -457,21 +524,19 @@
     "assert pending, f\"DO never saw job {JOB_NAME}\"\n",
     "assert pending[0].status == \"pending\", f\"Expected pending, got {pending[0].status}\"\n",
     "print(f\"DO sees job: {JOB_NAME} (status: {pending[0].status})\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Create auto-approval rule from the pending job\n",
     "result = syft_bg.auto_approve_job(pending[0], file_paths=[\"params.json\"])\n",
     "assert result.success, f\"auto_approve_job failed: {result.error}\"\n",
     "print(result)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -482,7 +547,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "rules = syft_bg.list_auto_approvals()\n",
     "assert JOB_NAME in rules, f\"Rule '{JOB_NAME}' not found in auto-approvals\"\n",
@@ -497,21 +564,19 @@
     "print(f\"  content-matched: {content_paths}\")\n",
     "print(f\"  name-matched:    {rule.file_paths}\")\n",
     "print(f\"  peers:           {rule.peers}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Also visible in status\n",
     "status = syft_bg.status\n",
     "assert JOB_NAME in status.auto_approvals, \"Rule should appear in syft_bg.status\"\n",
     "print(\"Rule visible in syft_bg.status\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -522,9 +587,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# The approve service polls every 5s \u2014 wait for it to pick up the job\n",
+    "# The approve service polls every 5s — wait for it to pick up the job\n",
     "for attempt in range(24):\n",
     "    job = next((j for j in do_client.jobs if j.name == JOB_NAME), None)\n",
     "    if job and job.status == \"done\":\n",
@@ -534,13 +601,13 @@
     "\n",
     "assert job and job.status == \"done\", f\"Job never completed, status: {job.status if job else 'missing'}\"\n",
     "print(f\"Job {JOB_NAME}: {job.status}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# DS fetches result\n",
     "ds_job = next((j for j in ds_client.jobs if j.name == JOB_NAME), None)\n",
@@ -550,20 +617,20 @@
     "result_data = json.loads(ds_job.output_paths[0].read_text())\n",
     "print(f\"DS received result: {result_data}\")\n",
     "assert result_data[\"params\"][\"run\"] == 1"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4d: Follow-up job \u2014 should be auto-approved (no manual intervention)"
+    "### 4d: Follow-up job — should be auto-approved (no manual intervention)"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "FOLLOWUP_NAME = f\"api_auto_{uuid.uuid4().hex[:8]}\"\n",
     "followup_dir = create_parameterized_job(main_file=\"main.py\", params={\"run\": 2})\n",
@@ -576,13 +643,13 @@
     "    force_submission=True,\n",
     ")\n",
     "print(f\"Submitted follow-up: {FOLLOWUP_NAME}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Wait for auto-approval + execution\n",
     "for attempt in range(24):\n",
@@ -596,13 +663,13 @@
     "    f\"Follow-up job not auto-approved/completed, status: {job2.status if job2 else 'missing'}\"\n",
     ")\n",
     "print(f\"Follow-up {FOLLOWUP_NAME}: {job2.status} (auto-approved!)\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# DS fetches follow-up result\n",
     "ds_job2 = next((j for j in ds_client.jobs if j.name == FOLLOWUP_NAME), None)\n",
@@ -611,9 +678,7 @@
     "result_data2 = json.loads(ds_job2.output_paths[0].read_text())\n",
     "print(f\"DS received follow-up result: {result_data2}\")\n",
     "assert result_data2[\"params\"][\"run\"] == 2"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -624,7 +689,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "remove_result = syft_bg.remove_auto_approve(JOB_NAME)\n",
     "assert remove_result.success, f\"Failed to remove: {remove_result.error}\"\n",
@@ -633,9 +700,7 @@
     "assert JOB_NAME not in rules_after, f\"Rule '{JOB_NAME}' should have been removed\"\n",
     "print(f\"Rule '{JOB_NAME}' removed\")\n",
     "print(f\"Remaining rules: {list(rules_after.keys()) or '(none)'}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -647,14 +712,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "for svc in (\"sync\", \"notify\", \"approve\"):\n",
     "    print(f\"\\n{'='*20} {svc} {'='*20}\")\n",
     "    syft_bg.logs(svc, n=20)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -665,12 +730,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "syft_bg.status"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -682,22 +747,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "syft_bg.stop()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Uncomment to fully reset all syft-bg state\n",
     "# syft_bg.reset()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/beach/internal/test_syft_bg.ipynb
+++ b/notebooks/beach/internal/test_syft_bg.ipynb
@@ -1,0 +1,716 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# syft-bg Integration Tests\n",
+    "\n",
+    "Reusable notebook that tests `syft_bg` service management:\n",
+    "\n",
+    "1. **Config & Status basics** \u2014 init, inspect config, check status\n",
+    "2. **Misconfigured `email_approve`** \u2014 missing `gcp_project_id` \u2192 graceful error\n",
+    "3. **Start / Stop / Restart** \u2014 verify PID lifecycle\n",
+    "4. **Auto-approve job via API** \u2014 `auto_approve_job()`, follow-up auto-approval, list/remove rules\n",
+    "\n",
+    "### Prerequisites\n",
+    "- `.env` file with `DO_EMAIL`, `DS_EMAIL`, `GCP_PROJECT_ID`, `APP_CREDENTIALS`, `TOKEN_DS`\n",
+    "- OAuth credential files (see Setup cells for first-time token generation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Environment & Credentials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import os\nfrom pathlib import Path\n\nfor line in Path(\".env\").read_text().splitlines():\n    if line.strip() and not line.startswith(\"#\"):\n        key, _, value = line.partition(\"=\")\n        os.environ.setdefault(key.strip(), value.strip())\n\nDO_EMAIL = os.environ[\"DO_EMAIL\"]\nDS_EMAIL = os.environ[\"DS_EMAIL\"]\nGCP_PROJECT_ID = os.environ[\"GCP_PROJECT_ID\"]\n\nAPP_CREDENTIALS = Path(os.environ[\"APP_CREDENTIALS\"])\nTOKEN_DS = Path(os.environ[\"TOKEN_DS\"])\nDO_CREDENTIALS = Path(\"/Users/bitsofsteve/code/syft-client/creds.stephen.json\")\nDO_TOKEN = Path(\"/Users/bitsofsteve/code/syft-client/notebooks/beach/internal/token_do.json\")\n\nassert APP_CREDENTIALS.exists(), f\"App credentials missing: {APP_CREDENTIALS}\"\nassert DO_CREDENTIALS.exists(), f\"DO credentials missing: {DO_CREDENTIALS}\"\n\nprint(f\"DO: {DO_EMAIL}\")\nprint(f\"DS: {DS_EMAIL}\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### First-time token generation\n",
+    "\n",
+    "Uncomment and run these cells once to generate OAuth tokens. Each opens a browser for consent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import syft_client as sc\n",
+    "\n",
+    "# --- DS token (Drive scopes only) ---\n",
+    "# sc.credentials_to_token(\n",
+    "#     credentials_path=str(APP_CREDENTIALS),\n",
+    "#     output_path=str(TOKEN_DS),\n",
+    "# )\n",
+    "# print(f\"DS token saved to: {TOKEN_DS}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# --- DO token (Drive + Gmail + PubSub scopes) ---\n# sc.credentials_to_token(\n#     credentials_path=str(DO_CREDENTIALS),\n#     output_path=str(DO_TOKEN),\n#     do_scopes=True,\n# )\n# print(f\"DO token saved to: {DO_TOKEN}\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "assert TOKEN_DS.exists(), f\"DS token missing: {TOKEN_DS} \u2014 uncomment generation cell above\"\nassert DO_TOKEN.exists(), f\"DO token missing: {DO_TOKEN} \u2014 uncomment generation cell above\"\nprint(\"All tokens ready\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Login & Peers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import syft_client as sc\n",
+    "\n",
+    "do_client = sc.login_do(email=DO_EMAIL, token_path=str(DO_TOKEN))\n",
+    "ds_client = sc.login_ds(email=DS_EMAIL, token_path=str(TOKEN_DS))"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "ds_client.add_peer(DO_EMAIL)\n",
+    "do_client.load_peers()\n",
+    "do_client.approve_peer_request(DS_EMAIL, peer_must_exist=False)\n",
+    "print(\"Peer relationship established\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Test Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "try:\n    do_client.create_dataset(\n        name=\"testdata\",\n        mock_path=\"data/mock.txt\",\n        private_path=\"data/private.txt\",\n        users=[DS_EMAIL],\n    )\nexcept FileExistsError:\n    print(\"Dataset 'testdata' already exists, skipping creation\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 1: Config & Status Basics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import syft_bg\n",
+    "\n",
+    "syft_bg.reset()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "syft_bg.init(\n",
+    "    do_email=DO_EMAIL,\n",
+    "    token_path=str(DO_TOKEN),\n",
+    "    settings={\n",
+    "        \"email_approve\": {\"gcp_project_id\": GCP_PROJECT_ID},\n",
+    "    },\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Inspect config \u2014 should show do_email, token paths, and gcp_project_id\n",
+    "syft_bg.config"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Status before starting any services \u2014 all should be stopped\n",
+    "status = syft_bg.status\n",
+    "print(status)\n",
+    "\n",
+    "for name, info in status.service_infos.items():\n",
+    "    assert info.status.value in (\"stopped\", \"unknown\"), f\"{name} should be stopped, got {info.status}\"\n",
+    "print(\"\\nAll services stopped as expected\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 2: Misconfigured `email_approve` (no `gcp_project_id`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Re-init WITHOUT gcp_project_id for email_approve\n",
+    "syft_bg.reset()\n",
+    "syft_bg.init(\n",
+    "    do_email=DO_EMAIL,\n",
+    "    token_path=str(DO_TOKEN),\n",
+    "    # intentionally no email_approve settings\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import time\n",
+    "\n",
+    "# Start only email_approve \u2014 it should fail during setup\n",
+    "syft_bg.ensure_running(services=[\"email_approve\"])\n",
+    "\n",
+    "# Give the subprocess time to attempt setup and write error state\n",
+    "time.sleep(5)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from syft_bg.services.base import ServiceStatus\n",
+    "\n",
+    "status = syft_bg.status\n",
+    "print(status)\n",
+    "\n",
+    "ea_info = status.service_infos[\"email_approve\"]\n",
+    "assert ea_info.status == ServiceStatus.ERROR, (\n",
+    "    f\"Expected email_approve to be in ERROR state, got {ea_info.status}\"\n",
+    ")\n",
+    "print(f\"\\nemail_approve correctly in ERROR state\")\n",
+    "print(f\"Error: {ea_info.error[:200] if ea_info.error else 'no error message'}...\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Check logs confirm the gcp_project_id error\n",
+    "log_lines = syft_bg.logs(\"email_approve\", n=30, as_list=True)\n",
+    "error_lines = [l for l in log_lines if \"gcp_project_id\" in l.lower() or \"GCP project ID\" in l]\n",
+    "assert error_lines, \"Expected gcp_project_id error in email_approve logs\"\n",
+    "print(\"Logs confirm missing gcp_project_id:\")\n",
+    "for line in error_lines:\n",
+    "    print(f\"  {line}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 3: Start / Stop / Restart Services"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Clean slate with proper config\n",
+    "syft_bg.reset()\n",
+    "syft_bg.init(\n",
+    "    do_email=DO_EMAIL,\n",
+    "    token_path=str(DO_TOKEN),\n",
+    "    settings={\n",
+    "        \"email_approve\": {\"gcp_project_id\": GCP_PROJECT_ID},\n",
+    "    },\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Start sync, notify, approve (skip email_approve \u2014 it needs Pub/Sub infra)\n# Start sync first so it creates the cache directory before approve needs it\nSERVICES = [\"sync\", \"notify\", \"approve\"]\n\nsyft_bg.ensure_running(services=[\"sync\"], restart=True)\ntime.sleep(10)  # let sync create .cache dir\n\nsyft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\ntime.sleep(5)\n\nstatus = syft_bg.status\nprint(status)",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Record initial PIDs\n",
+    "initial_pids = {}\n",
+    "for svc in SERVICES:\n",
+    "    info = status.service_infos[svc]\n",
+    "    assert info.status in (ServiceStatus.RUNNING, ServiceStatus.STARTING), (\n",
+    "        f\"{svc} should be running, got {info.status}\"\n",
+    "    )\n",
+    "    initial_pids[svc] = info.pid\n",
+    "    print(f\"{svc}: PID {info.pid} ({info.status.value})\")\n",
+    "\n",
+    "print(f\"\\nAll {len(SERVICES)} services running\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Restart the approve service \u2014 PID should change\n",
+    "syft_bg.restart(\"approve\")\n",
+    "time.sleep(3)\n",
+    "\n",
+    "new_status = syft_bg.status\n",
+    "new_approve_info = new_status.service_infos[\"approve\"]\n",
+    "assert new_approve_info.pid != initial_pids[\"approve\"], (\n",
+    "    f\"approve PID should have changed: was {initial_pids['approve']}, still {new_approve_info.pid}\"\n",
+    ")\n",
+    "print(f\"approve restarted: PID {initial_pids['approve']} -> {new_approve_info.pid}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Stop approve\n",
+    "syft_bg.stop(\"approve\")\n",
+    "time.sleep(1)\n",
+    "\n",
+    "stopped_status = syft_bg.status\n",
+    "assert stopped_status.service_infos[\"approve\"].status == ServiceStatus.STOPPED, (\n",
+    "    f\"approve should be stopped, got {stopped_status.service_infos['approve'].status}\"\n",
+    ")\n",
+    "print(\"approve stopped\")\n",
+    "\n",
+    "# Other services should still be running\n",
+    "for svc in [\"sync\", \"notify\"]:\n",
+    "    assert stopped_status.service_infos[svc].status in (ServiceStatus.RUNNING, ServiceStatus.STARTING), (\n",
+    "        f\"{svc} should still be running\"\n",
+    "    )\n",
+    "print(\"sync and notify still running\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Start approve again\n",
+    "syft_bg.start(\"approve\")\n",
+    "time.sleep(3)\n",
+    "\n",
+    "restarted_status = syft_bg.status\n",
+    "assert restarted_status.service_infos[\"approve\"].status in (ServiceStatus.RUNNING, ServiceStatus.STARTING), (\n",
+    "    f\"approve should be running again, got {restarted_status.service_infos['approve'].status}\"\n",
+    ")\n",
+    "print(f\"approve running again: PID {restarted_status.service_infos['approve'].pid}\")\n",
+    "print(\"\\nStart/Stop/Restart test passed\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 4: Auto-Approve Job via API\n",
+    "\n",
+    "DS submits a parameterized job. DO uses `syft_bg.auto_approve_job()` to create an\n",
+    "auto-approval rule. The `approve` service picks it up, runs the job, and auto-approves\n",
+    "a follow-up job with the same code but different params."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import json\n",
+    "import tempfile\n",
+    "import uuid\n",
+    "\n",
+    "def create_parameterized_job(main_file: str, params: dict) -> Path:\n",
+    "    \"\"\"Create a temp project dir with a script and params.json.\"\"\"\n",
+    "    project_dir = Path(tempfile.mkdtemp(prefix=\"syftbg_test_\"))\n",
+    "    (project_dir / main_file).write_text(\n",
+    "        'import os, json\\n'\n",
+    "        '\\n'\n",
+    "        'with open(\"params.json\") as f:\\n'\n",
+    "        '    params = json.load(f)\\n'\n",
+    "        '\\n'\n",
+    "        'os.makedirs(\"outputs\", exist_ok=True)\\n'\n",
+    "        'with open(\"outputs/result.json\", \"w\") as f:\\n'\n",
+    "        '    json.dump({\"params\": params, \"status\": \"done\"}, f)\\n'\n",
+    "        '\\n'\n",
+    "        'print(f\"Result: {params}\")\\n'\n",
+    "    )\n",
+    "    (project_dir / \"params.json\").write_text(json.dumps(params))\n",
+    "    return project_dir"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Ensure services are running for this test\nsyft_bg.ensure_running(services=[\"sync\"], restart=True)\ntime.sleep(10)\nsyft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\ntime.sleep(5)\nprint(syft_bg.status)",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4a: Submit a job and create auto-approval rule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "JOB_NAME = f\"api_auto_{uuid.uuid4().hex[:8]}\"\n",
+    "job_dir = create_parameterized_job(main_file=\"main.py\", params={\"run\": 1})\n",
+    "\n",
+    "ds_client.submit_python_job(\n",
+    "    user=DO_EMAIL,\n",
+    "    code_path=str(job_dir),\n",
+    "    job_name=JOB_NAME,\n",
+    "    entrypoint=\"main.py\",\n",
+    "    force_submission=True,\n",
+    ")\n",
+    "print(f\"Submitted: {JOB_NAME}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Wait for sync service to make the job visible on DO side\n",
+    "for attempt in range(12):\n",
+    "    pending = [j for j in do_client.jobs if j.name == JOB_NAME]\n",
+    "    if pending:\n",
+    "        break\n",
+    "    print(f\"  waiting for job to appear on DO side... ({attempt+1})\")\n",
+    "    time.sleep(5)\n",
+    "\n",
+    "assert pending, f\"DO never saw job {JOB_NAME}\"\n",
+    "assert pending[0].status == \"pending\", f\"Expected pending, got {pending[0].status}\"\n",
+    "print(f\"DO sees job: {JOB_NAME} (status: {pending[0].status})\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Create auto-approval rule from the pending job\n",
+    "result = syft_bg.auto_approve_job(pending[0], file_paths=[\"params.json\"])\n",
+    "assert result.success, f\"auto_approve_job failed: {result.error}\"\n",
+    "print(result)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4b: Verify auto-approval config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "rules = syft_bg.list_auto_approvals()\n",
+    "assert JOB_NAME in rules, f\"Rule '{JOB_NAME}' not found in auto-approvals\"\n",
+    "\n",
+    "rule = rules[JOB_NAME]\n",
+    "content_paths = {e.relative_path for e in rule.file_contents}\n",
+    "assert content_paths == {\"main.py\"}, f\"Expected content match on main.py, got {content_paths}\"\n",
+    "assert \"params.json\" in rule.file_paths, \"params.json should be name-only matched\"\n",
+    "assert DS_EMAIL in rule.peers, f\"DS email should be in peers, got {rule.peers}\"\n",
+    "\n",
+    "print(f\"Rule '{JOB_NAME}':\")\n",
+    "print(f\"  content-matched: {content_paths}\")\n",
+    "print(f\"  name-matched:    {rule.file_paths}\")\n",
+    "print(f\"  peers:           {rule.peers}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Also visible in status\n",
+    "status = syft_bg.status\n",
+    "assert JOB_NAME in status.auto_approvals, \"Rule should appear in syft_bg.status\"\n",
+    "print(\"Rule visible in syft_bg.status\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4c: Wait for the approve service to run the job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# The approve service polls every 5s \u2014 wait for it to pick up the job\n",
+    "for attempt in range(24):\n",
+    "    job = next((j for j in do_client.jobs if j.name == JOB_NAME), None)\n",
+    "    if job and job.status == \"done\":\n",
+    "        break\n",
+    "    print(f\"  job status: {job.status if job else 'not found'} ({attempt+1})\")\n",
+    "    time.sleep(5)\n",
+    "\n",
+    "assert job and job.status == \"done\", f\"Job never completed, status: {job.status if job else 'missing'}\"\n",
+    "print(f\"Job {JOB_NAME}: {job.status}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# DS fetches result\n",
+    "ds_job = next((j for j in ds_client.jobs if j.name == JOB_NAME), None)\n",
+    "assert ds_job, f\"DS can't see job {JOB_NAME}\"\n",
+    "assert ds_job.status == \"done\", f\"DS sees status {ds_job.status}\"\n",
+    "\n",
+    "result_data = json.loads(ds_job.output_paths[0].read_text())\n",
+    "print(f\"DS received result: {result_data}\")\n",
+    "assert result_data[\"params\"][\"run\"] == 1"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4d: Follow-up job \u2014 should be auto-approved (no manual intervention)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "FOLLOWUP_NAME = f\"api_auto_{uuid.uuid4().hex[:8]}\"\n",
+    "followup_dir = create_parameterized_job(main_file=\"main.py\", params={\"run\": 2})\n",
+    "\n",
+    "ds_client.submit_python_job(\n",
+    "    user=DO_EMAIL,\n",
+    "    code_path=str(followup_dir),\n",
+    "    job_name=FOLLOWUP_NAME,\n",
+    "    entrypoint=\"main.py\",\n",
+    "    force_submission=True,\n",
+    ")\n",
+    "print(f\"Submitted follow-up: {FOLLOWUP_NAME}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Wait for auto-approval + execution\n",
+    "for attempt in range(24):\n",
+    "    job2 = next((j for j in do_client.jobs if j.name == FOLLOWUP_NAME), None)\n",
+    "    if job2 and job2.status == \"done\":\n",
+    "        break\n",
+    "    print(f\"  follow-up status: {job2.status if job2 else 'not found'} ({attempt+1})\")\n",
+    "    time.sleep(5)\n",
+    "\n",
+    "assert job2 and job2.status == \"done\", (\n",
+    "    f\"Follow-up job not auto-approved/completed, status: {job2.status if job2 else 'missing'}\"\n",
+    ")\n",
+    "print(f\"Follow-up {FOLLOWUP_NAME}: {job2.status} (auto-approved!)\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# DS fetches follow-up result\n",
+    "ds_job2 = next((j for j in ds_client.jobs if j.name == FOLLOWUP_NAME), None)\n",
+    "assert ds_job2 and ds_job2.status == \"done\"\n",
+    "\n",
+    "result_data2 = json.loads(ds_job2.output_paths[0].read_text())\n",
+    "print(f\"DS received follow-up result: {result_data2}\")\n",
+    "assert result_data2[\"params\"][\"run\"] == 2"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4e: Remove auto-approval rule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "remove_result = syft_bg.remove_auto_approve(JOB_NAME)\n",
+    "assert remove_result.success, f\"Failed to remove: {remove_result.error}\"\n",
+    "\n",
+    "rules_after = syft_bg.list_auto_approvals()\n",
+    "assert JOB_NAME not in rules_after, f\"Rule '{JOB_NAME}' should have been removed\"\n",
+    "print(f\"Rule '{JOB_NAME}' removed\")\n",
+    "print(f\"Remaining rules: {list(rules_after.keys()) or '(none)'}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Debugging: Service Logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "for svc in (\"sync\", \"notify\", \"approve\"):\n",
+    "    print(f\"\\n{'='*20} {svc} {'='*20}\")\n",
+    "    syft_bg.logs(svc, n=20)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Final status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "syft_bg.status"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "syft_bg.stop()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Uncomment to fully reset all syft-bg state\n",
+    "# syft_bg.reset()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `notebooks/beach/internal/test_syft_bg.ipynb` — a reusable, fully automated integration test notebook for `syft_bg` service management
- No manual email interaction required; all tests are API-driven

### What's tested

1. **Config & Status basics** — `init()`, inspect `config`, verify all services report `stopped`
2. **Misconfigured `email_approve`** — start `email_approve` without `gcp_project_id`, assert `ERROR` status, confirm error message in logs
3. **Start / Stop / Restart** — start `sync`, `notify`, `approve`; verify PIDs; `restart("approve")` → new PID; `stop("approve")` → stopped while others run; `start("approve")` → running again
4. **Auto-approve job via API** — DS submits job → DO calls `auto_approve_job()` → verify config/rules/status → approve service runs job → DS fetches result → submit follow-up with same code/different params → auto-approved → `remove_auto_approve()` → verify removed

### Found issue: `approve` service race condition with `sync`

The `approve` service crashes on startup if `sync` hasn't completed its first cycle yet, because `SyftboxManager` tries to load cached state from `.cache/owner_file_hashes.json` which doesn't exist until sync creates it.

**Error:** `FileNotFoundError: '.cache/owner_file_hashes.tmp' -> '.cache/owner_file_hashes.json'`

**Suggested fix:** The `notify` service already handles this with `_wait_for_sync_ready()` — it polls for the `~/.syft-bg/sync/.sync_ready` marker file (written by `SyncOrchestrator` after its first successful cycle) with a 120s timeout. The `approve` service (`ApprovalOrchestrator`) should adopt the same pattern. Currently it has no sync-readiness check at all.

**Workaround in notebook:** Start `sync` first, sleep 10s, then start `notify`/`approve`.

## Test plan

- [x] Ran notebook end-to-end twice consecutively — all 4 tests pass
- [ ] Verify on a clean machine with fresh credentials