### PR TITLE
fix(syft-bg): add StatusResult.render and echo CLI status

### DIFF
--- a/packages/syft-bg/src/syft_bg/api/results.py
+++ b/packages/syft-bg/src/syft_bg/api/results.py
@@ -234,6 +234,11 @@ class StatusResult(BaseModel):
     def _approved_domains_contents(self) -> str:
         return "\n".join(f"  {d}" for d in self.approved_domains)
 
+    def render(self, as_html: bool = False) -> str:
+        if as_html:
+            return self._repr_html_()
+        return self.__repr__()
+
     def __repr__(self) -> str:
         from syft_bg.api.templates import (
             APPROVED_DOMAINS_SECTION,

--- a/packages/syft-bg/src/syft_bg/cli/commands.py
+++ b/packages/syft-bg/src/syft_bg/cli/commands.py
@@ -20,8 +20,7 @@ def status():
     """Show status of all services."""
     from syft_bg.api.api import status as api_status
 
-    status = api_status()
-    return status.render(as_html=False)
+    click.echo(api_status().render(as_html=False))
 
 
 @main.command()

--- a/tests/integration/syft_bg/test_cli.py
+++ b/tests/integration/syft_bg/test_cli.py
@@ -74,9 +74,9 @@ class TestStatusCommand:
         runner = CliRunner()
         result = runner.invoke(status)
 
-        assert "SYFT BACKGROUND SERVICES" in result.output
-        assert "SERVICE" in result.output
-        assert "STATUS" in result.output
+        assert "syft-bg status" in result.output
+        assert "services" in result.output
+        assert "tokens" in result.output
 
 
 class TestMainCommand:


### PR DESCRIPTION
## Summary
- Nightly integration tests have been failing on `tests/integration/syft_bg/test_cli.py::TestStatusCommand` since the `api/results` refactor.
- The `syft-bg status` CLI command in `commands.py` calls `StatusResult.render(as_html=False)`, but `StatusResult` only defines `__repr__` and `_repr_html_` — so every `runner.invoke(status)` raises `AttributeError("'StatusResult' object has no attribute 'render'")` and exits 1.
- Adds a thin `render()` on `StatusResult` that delegates to those, echoes the rendered output instead of returning it from the click command, and updates the test header assertions to match the current `STATUS_TEMPLATE` ("syft-bg status" / "tokens" / "services") instead of the pre-refactor "SYFT BACKGROUND SERVICES" banner.

## Test plan
- [x] `uv run pytest tests/integration/syft_bg/test_cli.py` — 23 passed locally
- [x] `pre-commit` clean on all touched files
- [ ] Nightly integration run goes green