### PR TITLE
feat: hide DO-only approve hint in jobs list repr from DS users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ notebooks/beach/internal/data/pdfs
 notebooks/beach/internal/data/manifest.csv
 notebooks/beach/internal/data/readme.md
 
+.agents/
+AGENTS.md

--- a/packages/syft-job/src/syft_job/client.py
+++ b/packages/syft-job/src/syft_job/client.py
@@ -64,6 +64,7 @@ class JobClient(BaseJobClient):
         self.target_datasite_owner_email = (
             target_datasite_owner_email or config.current_user_email
         )  # The email of the datasite owner of the jobs
+        self.has_do_role = config.has_do_role
 
         # Validate that user_email exists in SyftBox root
         self._validate_user_email()
@@ -647,7 +648,11 @@ python {entrypoint_path}
             )
 
         sorted_jobs = sorted(current_jobs, key=job_sort_key)
-        return JobsList(sorted_jobs, self.target_datasite_owner_email)
+        return JobsList(
+            sorted_jobs,
+            self.target_datasite_owner_email,
+            has_do_role=self.has_do_role,
+        )
 
 
 def get_client(

--- a/packages/syft-job/src/syft_job/config.py
+++ b/packages/syft-job/src/syft_job/config.py
@@ -8,6 +8,9 @@ class SyftJobConfig(BaseModel):
 
     syftbox_folder: Path = Field(..., description="Path to SyftBox root folder")
     current_user_email: str = Field(..., description="User email address")
+    has_do_role: bool = Field(
+        default=False, description="Whether the owning manager has the DO role"
+    )
 
     @property
     def syftbox_folder_path_str(self) -> str:

--- a/packages/syft-job/src/syft_job/job.py
+++ b/packages/syft-job/src/syft_job/job.py
@@ -401,9 +401,10 @@ class JobInfo:
 class JobsList:
     """A list-like container for JobInfo objects with nice display."""
 
-    def __init__(self, jobs: List[JobInfo], root_email: str):
+    def __init__(self, jobs: List[JobInfo], root_email: str, has_do_role: bool = False):
         self._jobs = jobs
         self._root_email = root_email
+        self._has_do_role = has_do_role
 
     def __getitem__(self, index: int | str) -> JobInfo:
         if isinstance(index, int):
@@ -423,10 +424,10 @@ class JobsList:
         return iter(self._jobs)
 
     def __str__(self) -> str:
-        return jobs_list_str(self._jobs, self._root_email)
+        return jobs_list_str(self._jobs, self._root_email, self._has_do_role)
 
     def __repr__(self) -> str:
         return f"JobsList({len(self._jobs)} jobs)"
 
     def _repr_html_(self) -> str:
-        return jobs_list_repr_html(self._jobs, self._root_email)
+        return jobs_list_repr_html(self._jobs, self._root_email, self._has_do_role)

--- a/packages/syft-job/src/syft_job/job_repr.py
+++ b/packages/syft-job/src/syft_job/job_repr.py
@@ -727,7 +727,9 @@ def job_info_repr_html(job: "JobInfo") -> str:
         """
 
 
-def jobs_list_str(jobs: List["JobInfo"], root_email: str) -> str:
+def jobs_list_str(
+    jobs: List["JobInfo"], root_email: str, has_do_role: bool = False
+) -> str:
     """Format jobs list as separate tables grouped by user."""
     if not jobs:
         return "📭 No jobs found.\n"
@@ -828,15 +830,18 @@ def jobs_list_str(jobs: List["JobInfo"], root_email: str) -> str:
     if global_summary_parts:
         lines.append("📋 Global: " + " | ".join(global_summary_parts))
 
-    lines.append("")
-    lines.append(
-        "💡 Use job_client.jobs[0].approve() to approve jobs or job_client.jobs[0].accept_by_depositing_result('file_or_folder') to complete jobs"
-    )
+    if has_do_role:
+        lines.append("")
+        lines.append(
+            "💡 Use job_client.jobs[0].approve() to approve jobs or job_client.jobs[0].accept_by_depositing_result('file_or_folder') to complete jobs"
+        )
 
     return "\n".join(lines)
 
 
-def jobs_list_repr_html(jobs: List["JobInfo"], root_email: str) -> str:
+def jobs_list_repr_html(
+    jobs: List["JobInfo"], root_email: str, has_do_role: bool = False
+) -> str:
     """HTML representation for Jupyter notebooks with enhanced visual appeal."""
     if not jobs:
         return """
@@ -1304,9 +1309,14 @@ def jobs_list_repr_html(jobs: List["JobInfo"], root_email: str) -> str:
 
     html += """
                 </div>
+        """
+    if has_do_role:
+        html += """
                 <div class="syftjob-hint">
                     💡 Use <code class="syftjob-code">jobs[0].approve()</code> to approve jobs or <code class="syftjob-code">jobs[0].accept_by_depositing_result('file_or_folder')</code> to complete jobs
                 </div>
+        """
+    html += """
             </div>
         </div>
         """

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -131,6 +131,7 @@ class SyftboxManagerConfig(BaseModel):
         job_client_config = SyftJobConfig(
             syftbox_folder=syftbox_folder,
             current_user_email=email,
+            has_do_role=has_do_role,
         )
         dataset_manager_config = SyftBoxConfig(
             syftbox_folder=syftbox_folder,
@@ -205,6 +206,7 @@ class SyftboxManagerConfig(BaseModel):
         job_client_config = SyftJobConfig(
             syftbox_folder=syftbox_folder,
             current_user_email=email,
+            has_do_role=has_do_role,
         )
         peer_manager_config = PeerManagerConfig(
             syftbox_folder=syftbox_folder,
@@ -270,6 +272,7 @@ class SyftboxManagerConfig(BaseModel):
         job_client_config = SyftJobConfig(
             syftbox_folder=Path(syftbox_folder),
             current_user_email=email,
+            has_do_role=has_do_role,
         )
         peer_manager_config = PeerManagerConfig(
             syftbox_folder=syftbox_folder,
@@ -345,6 +348,7 @@ class SyftboxManagerConfig(BaseModel):
         job_client_config = SyftJobConfig(
             syftbox_folder=syftbox_folder,
             current_user_email=email,
+            has_do_role=has_do_role,
         )
         peer_manager_config = PeerManagerConfig(
             syftbox_folder=syftbox_folder,


### PR DESCRIPTION
## Summary
- The jobs list HTML/string repr was emitting `Use jobs[0].approve() ... or jobs[0].accept_by_depositing_result(...)` to every viewer, but both are Data Owner operations and confusing for DS users.
- Threaded `has_do_role` from `SyftboxManager` through `SyftJobConfig` → `JobClient` → `JobsList` → `jobs_list_str` / `jobs_list_repr_html`, gating the hint behind it.
- Defaults to `False`, so direct `JobsList(...)` constructions and DS-only managers hide the hint by default.

## Test plan
- [x] `uv run pytest tests/unit/test_datasets_jobs_repr.py -v` (16/16 pass with the new default-`False` parameter signature)
- [x] `just test-unit-fast` (317 passed, 1 skipped)
- [ ] Notebook sanity: `do_manager.jobs._repr_html_()` contains the approve hint; `ds_manager.jobs._repr_html_()` does not.