### PR TITLE
feat: verify token-email match at login

### DIFF
--- a/notebooks/beach/internal/test_multiple_clients.ipynb
+++ b/notebooks/beach/internal/test_multiple_clients.ipynb
@@ -1,0 +1,487 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# syft-bg Integration Tests\n",
+    "\n",
+    "Reusable notebook that tests `syft_bg` service management:\n",
+    "\n",
+    "1. **Config & Status basics** — init, inspect config, check status\n",
+    "2. **Misconfigured `email_approve`** — missing `gcp_project_id` → graceful error\n",
+    "3. **Start / Stop / Restart** — verify PID lifecycle\n",
+    "4. **Auto-approve job via API** — `auto_approve_job()`, follow-up auto-approval, list/remove rules\n",
+    "\n",
+    "### Prerequisites\n",
+    "- `.env` file with `DO_EMAIL`, `DS_EMAIL`, `GCP_PROJECT_ID`, `APP_CREDENTIALS`, `TOKEN_DS`\n",
+    "- OAuth credential files (see Setup cells for first-time token generation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Environment & Credentials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "for line in Path(\".env\").read_text().splitlines():\n",
+    "    if line.strip() and not line.startswith(\"#\"):\n",
+    "        key, _, value = line.partition(\"=\")\n",
+    "        os.environ.setdefault(key.strip(), value.strip())\n",
+    "\n",
+    "DO_EMAIL = os.environ[\"DO_EMAIL\"]\n",
+    "DS_EMAIL = os.environ[\"DS_EMAIL\"]\n",
+    "GCP_PROJECT_ID = os.environ[\"GCP_PROJECT_ID\"]\n",
+    "\n",
+    "APP_CREDENTIALS = Path(os.environ[\"APP_CREDENTIALS\"])\n",
+    "TOKEN_DS = Path(os.environ[\"TOKEN_DS\"])\n",
+    "DO_CREDENTIALS = APP_CREDENTIALS / \"test_app_credentials.json\"\n",
+    "DO_TOKEN = Path(os.environ[\"TOKEN_DO_WITH_SCOPES\"])\n",
+    "\n",
+    "assert APP_CREDENTIALS.exists(), f\"App credentials missing: {APP_CREDENTIALS}\"\n",
+    "assert DO_CREDENTIALS.exists(), f\"DO credentials missing: {DO_CREDENTIALS}\"\n",
+    "\n",
+    "print(f\"DO: {DO_EMAIL}\")\n",
+    "print(f\"DS: {DS_EMAIL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### First-time token generation\n",
+    "\n",
+    "Uncomment and run these cells once to generate OAuth tokens. Each opens a browser for consent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft_client as sc\n",
+    "\n",
+    "# --- DS token (Drive scopes only) ---\n",
+    "# sc.credentials_to_token(\n",
+    "#     credentials_path=str(APP_CREDENTIALS),\n",
+    "#     output_path=str(TOKEN_DS),\n",
+    "# )\n",
+    "# print(f\"DS token saved to: {TOKEN_DS}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- DO token (Drive + Gmail + PubSub scopes) ---\n",
+    "# sc.credentials_to_token(\n",
+    "#     credentials_path=str(DO_CREDENTIALS),\n",
+    "#     output_path=str(DO_TOKEN),\n",
+    "#     do_scopes=True,\n",
+    "# )\n",
+    "# print(f\"DO token saved to: {DO_TOKEN}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert TOKEN_DS.exists(), f\"DS token missing: {TOKEN_DS} — uncomment generation cell above\"\n",
+    "assert DO_TOKEN.exists(), f\"DO token missing: {DO_TOKEN} — uncomment generation cell above\"\n",
+    "print(\"All tokens ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Login & Peers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DO_EMAIL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft_client as sc\n",
+    "\n",
+    "do_client = sc.login_do(email=DO_EMAIL, token_path=str(DO_TOKEN))\n",
+    "ds_client = sc.login_ds(email=DS_EMAIL, token_path=str(TOKEN_DS))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sc.delete_syftbox(email=DO_EMAIL, token_path=DO_TOKEN)\n",
+    "# sc.delete_syftbox(email=DS_EMAIL, token_path=TOKEN_DS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_client.add_peer(DO_EMAIL)\n",
+    "do_client.load_peers()\n",
+    "do_client.approve_peer_request(DS_EMAIL, peer_must_exist=False)\n",
+    "print(\"Peer relationship established\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup: Test Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    do_client.create_dataset(\n",
+    "        name=\"testdata\",\n",
+    "        mock_path=\"data/mock.txt\",\n",
+    "        private_path=\"data/private.txt\",\n",
+    "        users=[DS_EMAIL],\n",
+    "    )\n",
+    "except FileExistsError:\n",
+    "    print(\"Dataset 'testdata' already exists, skipping creation\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.sync()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 1: Config & Status Basics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft_bg\n",
+    "\n",
+    "syft_bg.reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "syft_bg.init(\n",
+    "    do_email=DO_EMAIL,\n",
+    "    token_path=str(DO_TOKEN),\n",
+    "    settings={\n",
+    "        \"email_approve\": {\"gcp_project_id\": GCP_PROJECT_ID},\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect config — should show do_email, token paths, and gcp_project_id\n",
+    "# syft_bg.config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# syft_bg.reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "syft_bg.ensure_running(services=[\"sync\", \"notify\", \"approve\", \"email_approve\"], restart=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Status before starting any services — all should be stopped\n",
+    "syft_bg.status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "syft_bg.logs(\"sync\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(5):\n",
+    "    do_client.sync()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.sync()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Submit job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uuid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile /tmp/job.py\n",
+    "print(\"A\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "JOB_NAME = f\"api_auto_{uuid.uuid4().hex[:8]}\"\n",
+    "\n",
+    "ds_client.submit_python_job(\n",
+    "    user=DO_EMAIL,\n",
+    "    code_path=\"/tmp/job.py\",\n",
+    "    job_name=\"test2\",\n",
+    ")\n",
+    "print(f\"Submitted: {JOB_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_client.jobs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean slate with proper config\n",
+    "syft_bg.reset()\n",
+    "syft_bg.init(\n",
+    "    do_email=DO_EMAIL,\n",
+    "    token_path=str(DO_TOKEN),\n",
+    "    settings={\n",
+    "        \"email_approve\": {\"gcp_project_id\": GCP_PROJECT_ID},\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start sync, notify, approve (skip email_approve — it needs Pub/Sub infra)\n",
+    "# Start sync first so it creates the cache directory before approve needs it\n",
+    "SERVICES = [\"sync\", \"notify\", \"approve\"]\n",
+    "\n",
+    "syft_bg.ensure_running(services=[\"sync\"], restart=True)\n",
+    "time.sleep(10)  # let sync create .cache dir\n",
+    "\n",
+    "syft_bg.ensure_running(services=[\"notify\", \"approve\"], restart=True)\n",
+    "time.sleep(5)\n",
+    "\n",
+    "status = syft_bg.status\n",
+    "print(status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Record initial PIDs\n",
+    "initial_pids = {}\n",
+    "for svc in SERVICES:\n",
+    "    info = status.service_infos[svc]\n",
+    "    assert info.status in (ServiceStatus.RUNNING, ServiceStatus.STARTING), (\n",
+    "        f\"{svc} should be running, got {info.status}\"\n",
+    "    )\n",
+    "    initial_pids[svc] = info.pid\n",
+    "    print(f\"{svc}: PID {info.pid} ({info.status.value})\")\n",
+    "\n",
+    "print(f\"\\nAll {len(SERVICES)} services running\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Restart the approve service — PID should change\n",
+    "syft_bg.restart(\"approve\")\n",
+    "time.sleep(3)\n",
+    "\n",
+    "new_status = syft_bg.status\n",
+    "new_approve_info = new_status.service_infos[\"approve\"]\n",
+    "assert new_approve_info.pid != initial_pids[\"approve\"], (\n",
+    "    f\"approve PID should have changed: was {initial_pids['approve']}, still {new_approve_info.pid}\"\n",
+    ")\n",
+    "print(f\"approve restarted: PID {initial_pids['approve']} -> {new_approve_info.pid}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stop approve\n",
+    "syft_bg.stop(\"approve\")\n",
+    "time.sleep(1)\n",
+    "\n",
+    "stopped_status = syft_bg.status\n",
+    "assert stopped_status.service_infos[\"approve\"].status == ServiceStatus.STOPPED, (\n",
+    "    f\"approve should be stopped, got {stopped_status.service_infos['approve'].status}\"\n",
+    ")\n",
+    "print(\"approve stopped\")\n",
+    "\n",
+    "# Other services should still be running\n",
+    "for svc in [\"sync\", \"notify\"]:\n",
+    "    assert stopped_status.service_infos[svc].status in (ServiceStatus.RUNNING, ServiceStatus.STARTING), (\n",
+    "        f\"{svc} should still be running\"\n",
+    "    )\n",
+    "print(\"sync and notify still running\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start approve again\n",
+    "syft_bg.start(\"approve\")\n",
+    "time.sleep(3)\n",
+    "\n",
+    "restarted_status = syft_bg.status\n",
+    "assert restarted_status.service_infos[\"approve\"].status in (ServiceStatus.RUNNING, ServiceStatus.STARTING), (\n",
+    "    f\"approve should be running again, got {restarted_status.service_infos['approve'].status}\"\n",
+    ")\n",
+    "print(f\"approve running again: PID {restarted_status.service_infos['approve'].pid}\")\n",
+    "print(\"\\nStart/Stop/Restart test passed\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/syft_client/sync/connections/base_connection.py
+++ b/syft_client/sync/connections/base_connection.py
@@ -19,6 +19,10 @@ class ConnectionConfig(BaseModel):
 class SyftboxPlatformConnection(BaseModel):
     config: ConnectionConfig | None = None
 
+    def get_authenticated_email(self) -> str:
+        """Return the email of the account behind the underlying credentials/transport."""
+        raise NotImplementedError()
+
     def watcher_send_proposed_file_changes_message(
         self, proposed_file_change_message: ProposedFileChangesMessage
     ):

--- a/syft_client/sync/connections/connection_router.py
+++ b/syft_client/sync/connections/connection_router.py
@@ -42,6 +42,9 @@ class ConnectionRouter(BaseModel):
     def add_connection(self, connection: SyftboxPlatformConnection):
         self.connections.append(connection)
 
+    def get_authenticated_email(self) -> str:
+        return self.connections[0].get_authenticated_email()
+
     def connection_for_send_message(self) -> SyftboxPlatformConnection:
         return self.connections[0]
 

--- a/syft_client/sync/connections/drive/gdrive_transport.py
+++ b/syft_client/sync/connections/drive/gdrive_transport.py
@@ -360,18 +360,7 @@ class GDriveConnection(SyftboxPlatformConnection):
         return check_env()
 
     def get_authenticated_email(self) -> str:
-        """Return the email of the Google account behind drive_service.
-
-        For mock-backed services (tests), the mock advertises its own email so
-        the same code path works without any Drive API call.
-        """
-        from syft_client.sync.connections.drive.mock_drive_service import (
-            MockDriveService,
-        )
-
-        if isinstance(self.drive_service, MockDriveService):
-            return self.drive_service.get_authenticated_email()
-
+        """Return the email of the Google account behind drive_service."""
         about = execute_with_retries(
             self.drive_service.about().get(fields="user(emailAddress)")
         )

--- a/syft_client/sync/connections/drive/gdrive_transport.py
+++ b/syft_client/sync/connections/drive/gdrive_transport.py
@@ -359,6 +359,24 @@ class GDriveConnection(SyftboxPlatformConnection):
     def environment(self) -> Environment:
         return check_env()
 
+    def get_authenticated_email(self) -> str:
+        """Return the email of the Google account behind drive_service.
+
+        For mock-backed services (tests), the mock advertises its own email so
+        the same code path works without any Drive API call.
+        """
+        from syft_client.sync.connections.drive.mock_drive_service import (
+            MockDriveService,
+        )
+
+        if isinstance(self.drive_service, MockDriveService):
+            return self.drive_service.get_authenticated_email()
+
+        about = execute_with_retries(
+            self.drive_service.about().get(fields="user(emailAddress)")
+        )
+        return about["user"]["emailAddress"]
+
     def create_personal_syftbox_folder(self) -> str:
         """Creates /SyftBox/{version}#{email}"""
         syftbox_folder_id = self.get_syftbox_folder_id()

--- a/syft_client/sync/connections/drive/mock_drive_service.py
+++ b/syft_client/sync/connections/drive/mock_drive_service.py
@@ -844,6 +844,10 @@ class MockDriveService:
             backing_store, current_user
         )
 
+    def get_authenticated_email(self) -> str:
+        """Email of the user this mock service acts as (used by GDriveConnection.get_authenticated_email)."""
+        return self._current_user
+
     def files(self) -> MockFilesResource:
         """Get the files resource."""
         return self._files_resource

--- a/syft_client/sync/connections/drive/mock_drive_service.py
+++ b/syft_client/sync/connections/drive/mock_drive_service.py
@@ -789,6 +789,27 @@ class MockPermissionsResource:
         )
 
 
+class MockAboutGetRequest:
+    """Mock request for about().get()."""
+
+    def __init__(self, current_user: str, fields: str | None = None):
+        self._current_user = current_user
+        self._fields = fields
+
+    def execute(self) -> Dict[str, Any]:
+        return {"user": {"emailAddress": self._current_user}}
+
+
+class MockAboutResource:
+    """Mock about() resource."""
+
+    def __init__(self, current_user: str):
+        self._current_user = current_user
+
+    def get(self, fields: str | None = None) -> MockAboutGetRequest:
+        return MockAboutGetRequest(self._current_user, fields=fields)
+
+
 class MockBatchHttpRequest:
     """Mock BatchHttpRequest for batch operations."""
 
@@ -844,10 +865,6 @@ class MockDriveService:
             backing_store, current_user
         )
 
-    def get_authenticated_email(self) -> str:
-        """Email of the user this mock service acts as (used by GDriveConnection.get_authenticated_email)."""
-        return self._current_user
-
     def files(self) -> MockFilesResource:
         """Get the files resource."""
         return self._files_resource
@@ -855,6 +872,10 @@ class MockDriveService:
     def permissions(self) -> MockPermissionsResource:
         """Get the permissions resource."""
         return self._permissions_resource
+
+    def about(self) -> MockAboutResource:
+        """Get the about resource (built fresh so _current_user changes are picked up)."""
+        return MockAboutResource(self._current_user)
 
     def new_batch_http_request(self, callback=None) -> MockBatchHttpRequest:
         """Create a new batch HTTP request."""

--- a/syft_client/sync/login.py
+++ b/syft_client/sync/login.py
@@ -12,10 +12,22 @@ from syft_client.sync.config.config import settings
 from syft_client.sync.login_utils import handle_potential_version_mismatches_on_login
 
 
+def _verify_token_matches_email(client: SyftboxManager) -> None:
+    """Raise if the email login was called with doesn't match the token's account."""
+    actual = client._connection_router.get_authenticated_email()
+    if actual.lower() != client.email.lower():
+        raise ValueError(
+            f"Token/email mismatch: login was called with email={client.email!r} "
+            f"but the provided token authenticates as {actual!r}. "
+            f"Check that the token file matches the email."
+        )
+
+
 def _init_client_login(
     client: SyftboxManager, sync: bool, load_peers: bool
 ) -> SyftboxManager:
     """Common post-creation initialization: write version, sync, load peers."""
+    _verify_token_matches_email(client)
     print_client_connecting(client.email)
     client.write_local_version()
 

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -1512,6 +1512,9 @@ class SyftboxManager(BaseModel):
 
         # Delete local syftbox folder and cache directories
         self._delete_local_dirs()
+        print(
+            "Done, if you are also running syft-bg, make sure to call syft-bg.reset() before delete_syftbox()."
+        )
 
     def _delete_local_dirs(self):
         """Delete local syftbox folder and cache directories."""

--- a/tests/integration/without_unit_coverage/test_login.py
+++ b/tests/integration/without_unit_coverage/test_login.py
@@ -117,6 +117,23 @@ def test_login_do_with_sync_and_load_peers():
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.usefixtures("check_credentials")
+def test_login_ds_email_mismatch_raises():
+    """Login must fail fast when the email doesn't match the token's account."""
+    with pytest.raises(ValueError, match="Token/email mismatch") as exc_info:
+        sc.login_ds(
+            email=EMAIL_DO,  # intentionally wrong: DO's email with DS's token
+            token_path=token_path_ds,
+            sync=False,
+            load_peers=False,
+        )
+
+    msg = str(exc_info.value)
+    assert EMAIL_DO in msg
+    assert EMAIL_DS in msg
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_login_ds_missing_token_path_raises(monkeypatch):
     """Test that login_ds raises error when token_path is missing in Jupyter env."""
     # Unset the env var so the test can verify the error is raised

--- a/tests/unit/test_login_email_check.py
+++ b/tests/unit/test_login_email_check.py
@@ -1,0 +1,41 @@
+import pytest
+
+from syft_client.sync.login import _verify_token_matches_email
+from syft_client.sync.syftbox_manager import SyftboxManager
+
+
+def test_get_authenticated_email_matches_constructor_email():
+    ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection()
+
+    assert ds_manager._connection_router.get_authenticated_email() == ds_manager.email
+    assert do_manager._connection_router.get_authenticated_email() == do_manager.email
+
+
+def test_verify_token_matches_email_passes_when_matching():
+    ds_manager, _ = SyftboxManager.pair_with_mock_drive_service_connection()
+    _verify_token_matches_email(ds_manager)
+
+
+def _drive_service(manager):
+    return manager._connection_router.connections[0].drive_service
+
+
+def test_verify_token_matches_email_raises_on_mismatch():
+    ds_manager, _ = SyftboxManager.pair_with_mock_drive_service_connection()
+
+    _drive_service(ds_manager)._current_user = "someone-else@gmail.com"
+
+    with pytest.raises(ValueError, match="Token/email mismatch") as exc_info:
+        _verify_token_matches_email(ds_manager)
+
+    msg = str(exc_info.value)
+    assert ds_manager.email in msg
+    assert "someone-else@gmail.com" in msg
+
+
+def test_verify_token_matches_email_is_case_insensitive():
+    ds_manager, _ = SyftboxManager.pair_with_mock_drive_service_connection()
+
+    _drive_service(ds_manager)._current_user = ds_manager.email.upper()
+
+    _verify_token_matches_email(ds_manager)


### PR DESCRIPTION
## Summary
- Add `get_authenticated_email()` to the platform connection abstraction; implemented for `GDriveConnection` (via `about().get`) and `MockDriveService` (returns its constructor email).
- Wire a `_verify_token_matches_email` check into `_init_client_login` so `login_do` / `login_ds` fail fast with a clear error when the email doesn't match the OAuth token's account. Comparison is case-insensitive; runs before sync/peer-load.
- Covers Colab, where the same mismatch is possible if the caller passes an explicit email different from the live session's signed-in account.
- Existing in-memory unit tests are unaffected (mock advertises its own email, so the check is a no-op there).

## Test plan
- [x] `just test-unit-fast` (325 passed)
- [x] New unit tests: `tests/unit/test_login_email_check.py` (4 tests — happy path, mismatch raises with both emails in message, case-insensitive)
- [x] New targeted integration test: `tests/integration/without_unit_coverage/test_login.py::test_login_ds_email_mismatch_raises` (passes against real GDrive)
- [x] `pre-commit` on changed files