### PR TITLE
feat(syft-bg): add heartbeat email to notify service

### DIFF
--- a/packages/syft-bg/src/syft_bg/notify/config.py
+++ b/packages/syft-bg/src/syft_bg/notify/config.py
@@ -31,3 +31,5 @@ class NotifyConfig(BaseModel):
     interval: int = 30
     monitor_jobs: bool = True
     monitor_peers: bool = True
+    heartbeat_enabled: bool = True
+    heartbeat_interval: int = 86400

--- a/packages/syft-bg/src/syft_bg/notify/email_templates/templates/emails/heartbeat.html
+++ b/packages/syft-bg/src/syft_bg/notify/email_templates/templates/emails/heartbeat.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %} {% block title %}syft-bg heartbeat{% endblock %} {%
+block content %}
+<h1
+  style="color: #2d3748; font-size: 24px; font-weight: 600; margin: 0 0 16px 0"
+>
+  syft-bg is still running
+</h1>
+
+<p
+  style="color: #4a5568; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0"
+>
+  This is a heartbeat email from your syft-bg notify service. Receiving it
+  confirms that the service is still up and your Gmail token is still valid.
+</p>
+
+{% set info_items = [ {'label': 'Account', 'value': do_email}, {'label': 'Sent',
+'value': timestamp | datetime if timestamp else 'Just now'}, {'label':
+'Heartbeat interval', 'value': interval_human}, {'label': 'Status', 'value':
+'Healthy', 'badge': 'success'} ] %} {% include 'components/info_box.html' %}
+
+<p
+  style="
+    color: #718096;
+    font-size: 14px;
+    margin-top: 30px;
+    border-top: 1px solid #e2e8f0;
+    padding-top: 20px;
+  "
+>
+  If you stop receiving these emails, syft-bg may have been shut down or its
+  Gmail token may have expired. Check the service status with
+  <code>syft-bg status</code>.
+</p>
+{% endblock %}

--- a/packages/syft-bg/src/syft_bg/notify/gmail/sender.py
+++ b/packages/syft-bg/src/syft_bg/notify/gmail/sender.py
@@ -13,6 +13,17 @@ from googleapiclient.discovery import build
 from syft_bg.notify.email_templates import TemplateRenderer
 
 
+def _format_interval(seconds: int) -> str:
+    """Render an interval as a short human string (e.g. '60s', '5m', '24h')."""
+    if seconds % 86400 == 0 and seconds >= 86400:
+        return f"{seconds // 86400}d"
+    if seconds % 3600 == 0 and seconds >= 3600:
+        return f"{seconds // 3600}h"
+    if seconds % 60 == 0 and seconds >= 60:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"
+
+
 @dataclass
 class SendResult:
     """Result of sending an email."""
@@ -85,6 +96,41 @@ class GmailSender:
                 f"[GmailSender] Failed to send to {to_email}: {traceback.format_exc()}"
             )
             return SendResult(success=False, error_message=str(traceback.format_exc()))
+
+    def notify_heartbeat(
+        self,
+        do_email: str,
+        interval_seconds: int,
+        timestamp: Optional[datetime] = None,
+    ) -> SendResult:
+        """Send a heartbeat email confirming the service is still running."""
+        subject = "heartbeat: syft-bg still running, token is active"
+        ts = timestamp or datetime.now()
+        interval_human = _format_interval(interval_seconds)
+        body_text = (
+            "syft-bg is still running.\n\n"
+            f"Account: {do_email}\n"
+            f"Sent: {ts:%Y-%m-%d %H:%M:%S}\n"
+            f"Heartbeat interval: {interval_human}\n\n"
+            "Receiving this email confirms the notify service is up and the "
+            "Gmail token is still valid. If these stop arriving, check "
+            "`syft-bg status`.\n"
+        )
+        body_html = None
+        if self.use_html and self.renderer:
+            try:
+                body_html = self.renderer.render(
+                    "emails/heartbeat.html",
+                    {
+                        "do_email": do_email,
+                        "timestamp": ts,
+                        "interval_human": interval_human,
+                    },
+                )
+            except Exception:
+                pass
+
+        return self.send_email(do_email, subject, body_text, body_html)
 
     def notify_new_job(
         self,

--- a/packages/syft-bg/src/syft_bg/notify/heartbeat.py
+++ b/packages/syft-bg/src/syft_bg/notify/heartbeat.py
@@ -1,0 +1,66 @@
+"""Heartbeat thread for the notify service.
+
+Periodically emails the data owner so they know the service is still running
+and the Gmail token is still valid. Absence of the email is the alert signal.
+"""
+
+import threading
+import traceback
+from datetime import datetime
+from typing import Optional
+
+from syft_bg.notify.gmail.sender import GmailSender
+
+
+class Heartbeat:
+    """Sends a heartbeat email at startup and on a fixed interval."""
+
+    def __init__(
+        self,
+        sender: GmailSender,
+        do_email: str,
+        interval: int,
+        stop_event: Optional[threading.Event] = None,
+    ):
+        self.sender = sender
+        self.do_email = do_email
+        self.interval = interval
+        self._stop_event = stop_event or threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> threading.Thread:
+        """Start the heartbeat thread; returns the thread."""
+        thread = threading.Thread(target=self._run, daemon=True, name="Heartbeat")
+        self._thread = thread
+        thread.start()
+        return thread
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _run(self) -> None:
+        print(f"[Heartbeat] Started (interval: {self.interval}s)")
+        # Send one immediately, then loop on the interval.
+        self._send_one()
+        while not self._stop_event.is_set():
+            interrupted = self._stop_event.wait(self.interval)
+            if interrupted:
+                break
+            self._send_one()
+        print("[Heartbeat] Stopped")
+
+    def _send_one(self) -> None:
+        try:
+            result = self.sender.notify_heartbeat(
+                do_email=self.do_email,
+                interval_seconds=self.interval,
+                timestamp=datetime.now(),
+            )
+            if result.success:
+                print(
+                    f"[Heartbeat] sent at {datetime.now().isoformat(timespec='seconds')}"
+                )
+            else:
+                print(f"[Heartbeat] send failed: {result.error_message}")
+        except Exception:
+            print(f"[Heartbeat] send raised:\n{traceback.format_exc()}")

--- a/packages/syft-bg/src/syft_bg/notify/orchestrator.py
+++ b/packages/syft-bg/src/syft_bg/notify/orchestrator.py
@@ -2,13 +2,14 @@
 
 from typing import Optional
 
-from syft_bg.common.orchestrator import BaseOrchestrator
+from syft_bg.common.orchestrator import BaseOrchestrator, MonitorType
 from syft_bg.common.state import JsonStateManager
 from syft_bg.notify.config import NotifyConfig
 from syft_bg.notify.gmail.auth import GmailAuth
 from syft_bg.notify.gmail.sender import GmailSender
 from syft_bg.notify.handlers.job import JobHandler
 from syft_bg.notify.handlers.peer import PeerHandler
+from syft_bg.notify.heartbeat import Heartbeat
 from syft_bg.notify.monitors.job import JobMonitor
 from syft_bg.notify.monitors.peer import PeerMonitor
 
@@ -21,11 +22,13 @@ class NotificationOrchestrator(BaseOrchestrator):
         config: NotifyConfig,
         job_monitor: JobMonitor,
         peer_monitor: Optional[PeerMonitor] = None,
+        heartbeat: Optional[Heartbeat] = None,
     ):
         super().__init__()
         self.config = config
         self._job_monitor = job_monitor
         self._peer_monitor: Optional[PeerMonitor] = peer_monitor
+        self._heartbeat: Optional[Heartbeat] = heartbeat
 
     def _init_monitors(self):
         """No-op: monitors are created in from_config."""
@@ -84,10 +87,19 @@ class NotificationOrchestrator(BaseOrchestrator):
             sync_state=sync_state,
         )
 
+        heartbeat: Optional[Heartbeat] = None
+        if config.heartbeat_enabled:
+            heartbeat = Heartbeat(
+                sender=sender,
+                do_email=config.do_email,
+                interval=config.heartbeat_interval,
+            )
+
         return cls(
             config=config,
             job_monitor=job_monitor,
             peer_monitor=peer_monitor,
+            heartbeat=heartbeat,
         )
 
     def notify_peer_granted(self, ds_email: str) -> bool:
@@ -109,10 +121,38 @@ class NotificationOrchestrator(BaseOrchestrator):
             f"[PeerMonitor] Seeded {len(snapshot.peer_emails)} existing peers on fresh state"
         )
 
+    def start(self, monitor_type: Optional[MonitorType] = None) -> "BaseOrchestrator":
+        result = super().start(monitor_type)
+        self._start_heartbeat()
+        return result
+
+    def run_loop(self, monitor_type: Optional[MonitorType] = None) -> None:
+        # Share the orchestrator's stop event with heartbeat so a single
+        # KeyboardInterrupt / stop() takes the heartbeat down too.
+        self._stop_event.clear()
+        self._start_heartbeat()
+        super().run_loop(monitor_type)
+
+    def stop(self) -> None:
+        if self._heartbeat is not None:
+            self._heartbeat.stop()
+        super().stop()
+
+    def _start_heartbeat(self) -> None:
+        if self._heartbeat is None:
+            return
+        # Wire the orchestrator's shared stop_event into heartbeat so stop()
+        # / run_loop() exit interrupts the heartbeat sleep.
+        self._heartbeat._stop_event = self._stop_event
+        thread = self._heartbeat.start()
+        self._threads.append(thread)
+
     def _print_startup_info(self):
         """Print startup info for notify service."""
         print("Starting notification daemon...")
         print(f"  DO: {self.config.do_email}")
         print(f"  SyftBox: {self.config.syftbox_root}")
         print(f"  Interval: {self.config.interval}s")
+        if self.config.heartbeat_enabled:
+            print(f"  Heartbeat: every {self.config.heartbeat_interval}s")
         print()

--- a/tests/unit/syft_bg/test_heartbeat.py
+++ b/tests/unit/syft_bg/test_heartbeat.py
@@ -1,0 +1,81 @@
+"""Tests for the syft-bg notify Heartbeat thread."""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+from syft_bg.notify.gmail.sender import SendResult
+from syft_bg.notify.heartbeat import Heartbeat
+
+
+class TestHeartbeat:
+    """Tests for Heartbeat lifecycle and emitted email contents."""
+
+    def test_sends_immediately_then_periodically(self):
+        """First send is at startup, then once per interval; stops cleanly."""
+        sender = MagicMock()
+        sender.notify_heartbeat.return_value = SendResult(success=True)
+
+        stop_event = threading.Event()
+        heartbeat = Heartbeat(
+            sender=sender,
+            do_email="do@test.com",
+            interval=1,
+            stop_event=stop_event,
+        )
+
+        thread = heartbeat.start()
+        # Wait long enough for the startup send + at least one interval tick.
+        time.sleep(2.5)
+        heartbeat.stop()
+        thread.join(timeout=2)
+
+        assert not thread.is_alive(), "heartbeat thread did not stop"
+        assert sender.notify_heartbeat.call_count >= 2
+
+        first_call = sender.notify_heartbeat.call_args_list[0]
+        assert first_call.kwargs["do_email"] == "do@test.com"
+        assert first_call.kwargs["interval_seconds"] == 1
+
+    def test_continues_on_send_failure(self):
+        """A single failed send must not kill the heartbeat loop."""
+        sender = MagicMock()
+        sender.notify_heartbeat.side_effect = [
+            Exception("boom"),
+            SendResult(success=True),
+            SendResult(success=True),
+        ]
+
+        heartbeat = Heartbeat(
+            sender=sender,
+            do_email="do@test.com",
+            interval=1,
+        )
+
+        thread = heartbeat.start()
+        time.sleep(2.5)
+        heartbeat.stop()
+        thread.join(timeout=2)
+
+        assert sender.notify_heartbeat.call_count >= 2
+
+    def test_subject_is_exact(self):
+        """Sanity check: the subject string is the exact one we promised."""
+        from syft_bg.notify.gmail.sender import GmailSender
+
+        # Bypass __init__ so we don't need real credentials.
+        sender = GmailSender.__new__(GmailSender)
+        sender.use_html = False
+        sender._renderer = None
+        sender.send_email = MagicMock(
+            return_value=SendResult(success=True, thread_id=None)
+        )
+
+        sender.notify_heartbeat(do_email="do@test.com", interval_seconds=86400)
+
+        sender.send_email.assert_called_once()
+        args = sender.send_email.call_args.args
+        # send_email(to_email, subject, body_text, body_html)
+        assert args[0] == "do@test.com"
+        assert args[1] == "heartbeat: syft-bg still running, token is active"
+        assert "syft-bg is still running" in args[2]


### PR DESCRIPTION
- New daemon thread sends a heartbeat email at startup and every \`heartbeat_interval\` seconds (default 24h, configurable per service via \`NotifyConfig\`). Subject is \`heartbeat: syft-bg still running, token is active\` so absence of email is the alert that the service or Gmail token is dead.
- Wired into \`NotificationOrchestrator\` so \`run_loop()\` / \`start()\` spin it up and \`stop()\` / Ctrl+C drains it via the orchestrator's shared stop event. \`run_once()\` is intentionally untouched.
- Manual test against real Gmail with \`heartbeat_interval=60\` confirmed two heartbeats 60s apart in the daemon log; reset cleaned everything up.