### PR TITLE
fix: validate nested dicts in set_service_config against pydantic models

### DIFF
--- a/packages/syft-bg/src/syft_bg/common/syft_bg_config.py
+++ b/packages/syft-bg/src/syft_bg/common/syft_bg_config.py
@@ -75,6 +75,9 @@ class SyftBgConfig(BaseModel):
         for key, value in config.items():
             if key not in subconfig.model_fields:
                 raise ValueError(f"Unknown config key: {key}")
+            field_type = subconfig.model_fields[key].annotation
+            if isinstance(value, dict) and isinstance(field_type, type) and issubclass(field_type, BaseModel):
+                value = field_type.model_validate(value)
             setattr(subconfig, key, value)
 
     def _repr_html_(self) -> str:

--- a/packages/syft-bg/src/syft_bg/common/syft_bg_config.py
+++ b/packages/syft-bg/src/syft_bg/common/syft_bg_config.py
@@ -76,7 +76,11 @@ class SyftBgConfig(BaseModel):
             if key not in subconfig.model_fields:
                 raise ValueError(f"Unknown config key: {key}")
             field_type = subconfig.model_fields[key].annotation
-            if isinstance(value, dict) and isinstance(field_type, type) and issubclass(field_type, BaseModel):
+            if (
+                isinstance(value, dict)
+                and isinstance(field_type, type)
+                and issubclass(field_type, BaseModel)
+            ):
                 value = field_type.model_validate(value)
             setattr(subconfig, key, value)
 


### PR DESCRIPTION
## Issue
Raw dictionary input to automatic peer approval causes an issue during serialization.
```
syft_bg.init(
  settings={
      "approve": {
          "peers": {
              "enabled": True,
              "approved_domains": ["openmined.org", "gmail.com"],
              "auto_share_datasets": ["my_dataset"],
          },
      },
  },
)
```

## Fix Summary
- `set_service_config` now validates raw dicts against the field's pydantic `BaseModel` type annotation before calling `setattr`
- Fixes the issue where `setattr(subconfig, "peers", {"enabled": True, ...})` set a raw dict where pydantic expects a `PeerApprovalConfig`, causing warnings during serialization

## Test plan
- [x] `just test-unit-fast` passes (328 passed)
- [x] Manual verification: `cfg.set_service_config('approve', {'peers': {'enabled': True, ...}})` now produces a proper `PeerApprovalConfig` instance