### PR TITLE
feat: patch-tolerant version compatibility with top-level override

### DIFF
--- a/syft_client/sync/login_utils.py
+++ b/syft_client/sync/login_utils.py
@@ -92,11 +92,11 @@ def handle_potential_version_mismatches_on_login(
     remote_version = _read_remote_version(resolved_email, resolved_token_path)
 
     current_version = VersionInfo.current()
-    local_compatible = current_version.is_compatible_with(
-        local_version, compatible_if_unknown=True
+    local_compatible = local_version is None or current_version.is_compatible_with(
+        local_version
     )
-    remote_compatible = current_version.is_compatible_with(
-        remote_version, compatible_if_unknown=True
+    remote_compatible = remote_version is None or current_version.is_compatible_with(
+        remote_version
     )
 
     if not (local_compatible and remote_compatible):

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -3,7 +3,6 @@ import fcntl
 from syft_client.sync.peers.peer_store import PeerStore
 import logging
 import shutil
-import warnings
 from contextlib import contextmanager
 from syft_client.sync.connections.drive.gdrive_transport import GDriveConnection
 from syft_client.utils import resolve_path
@@ -56,6 +55,7 @@ from syft_client.sync.sync.datasite_watcher_syncer import (
     DatasiteWatcherSyncerConfig,
 )
 from syft_client.sync.version.peer_manager import (
+    CompatAction,
     PeerManager,
     PeerManagerConfig,
 )
@@ -278,7 +278,7 @@ class SyftboxManagerConfig(BaseModel):
             syftbox_folder=syftbox_folder,
             connection_configs=[],  # Empty for in-memory, connections added later
             n_threads=2,  # Use fewer threads for testing
-            force_allow_incompatible_peers=not check_versions,
+            force_ignore_peer_version=not check_versions,
             has_do_role=has_do_role,
             has_ds_role=has_ds_role,
         )
@@ -352,7 +352,7 @@ class SyftboxManagerConfig(BaseModel):
         peer_manager_config = PeerManagerConfig(
             syftbox_folder=syftbox_folder,
             connection_configs=connection_configs,
-            force_allow_incompatible_peers=not check_versions,
+            force_ignore_peer_version=not check_versions,
             has_do_role=has_do_role,
             has_ds_role=has_ds_role,
         )
@@ -423,7 +423,6 @@ class SyftboxManager(BaseModel):
         "should_create_checkpoint",
         "try_create_checkpoint",
         "delete_syftbox",
-        "read_own_version",
         "write_own_version",
     )
 
@@ -798,13 +797,17 @@ class SyftboxManager(BaseModel):
         job_name: str = "",
         sync=True,
         force_submission: bool = False,
-        allow_incompatible_peer: bool = False,
+        ignore_peer_version: bool = False,
     ):
         # Check version compatibility before submission (uses cached versions)
         if not force_submission:
-            self.peer_manager.check_version_for_submission(
-                user, force=False, allow_incompatible=allow_incompatible_peer
+            result = self.peer_manager.get_peer_compatibility_status(
+                user,
+                action=CompatAction.SUBMIT,
+                ignore_peer_version=ignore_peer_version,
             )
+            result.raise_on_skip(operation="submit job")
+            result.maybe_warn()
         job_dir = self.job_client.submit_bash_job(user, script, job_name=job_name)
         self.push_job_files(job_dir)
 
@@ -817,7 +820,7 @@ class SyftboxManager(BaseModel):
         entrypoint: str | None = None,
         sync=True,
         force_submission: bool = False,
-        allow_incompatible_peer: bool = False,
+        ignore_peer_version: bool = False,
     ):
         peer_emails = {p.email for p in self.peer_manager.syncable_peers}
         if user not in peer_emails:
@@ -838,9 +841,13 @@ class SyftboxManager(BaseModel):
 
         # Check version compatibility before submission (uses cached versions)
         if not force_submission:
-            self.peer_manager.check_version_for_submission(
-                user, force=False, allow_incompatible=allow_incompatible_peer
+            result = self.peer_manager.get_peer_compatibility_status(
+                user,
+                action=CompatAction.SUBMIT,
+                ignore_peer_version=ignore_peer_version,
             )
+            result.raise_on_skip(operation="submit job")
+            result.maybe_warn()
         job_dir = self.job_client.submit_python_job(
             user,
             code_path,
@@ -891,7 +898,7 @@ class SyftboxManager(BaseModel):
         auto_compact: bool = True,
         compact_threshold: int = MIN_MESSAGES_COMPACT,
         force_download_peer_state: bool = False,
-        allow_incompatible_peers: bool = False,
+        ignore_peer_version: bool = False,
     ):
         """
         Sync local state with Google Drive.
@@ -914,10 +921,11 @@ class SyftboxManager(BaseModel):
             self.load_peers(force_download=force_download_peer_state)
             if self.has_do_role:
                 peer_emails = [peer.email for peer in self.peer_manager.approved_peers]
-                compatible_emails = self.peer_manager.get_compatible_peer_emails(
-                    peer_emails,
-                    warn_incompatible=True,
-                    allow_incompatible=allow_incompatible_peers,
+                compatible_emails = (
+                    self.peer_manager.get_compatible_peer_emails_for_syncing(
+                        peer_emails,
+                        ignore_peer_version=ignore_peer_version,
+                    )
                 )
                 self.datasite_owner_syncer.sync(compatible_emails)
                 if auto_compact:
@@ -1022,7 +1030,7 @@ class SyftboxManager(BaseModel):
         force_execution: bool = False,
         share_outputs_with_submitter: bool = False,
         share_logs_with_submitter: bool = False,
-        allow_incompatible_peer: bool = False,
+        ignore_peer_version: bool = False,
     ) -> None:
         """
         Process approved jobs. Automatically calls sync() after processing
@@ -1048,13 +1056,12 @@ class SyftboxManager(BaseModel):
                 job for job in self.job_client.jobs if job.status == "approved"
             ]
             for job in approved_jobs:
-                result = self.peer_manager.should_skip_job_for_processing(
+                result = self.peer_manager.get_peer_compatibility_status(
                     job.submitted_by,
-                    job.name,
-                    allow_incompatible_peer=allow_incompatible_peer,
+                    action=CompatAction.EXECUTE,
+                    ignore_peer_version=ignore_peer_version,
                 )
-                if result.warning_message:
-                    warnings.warn(result.warning_message)
+                result.maybe_warn()
                 if result.should_skip:
                     skip_job_names.append(job.name)
 

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -278,8 +278,7 @@ class SyftboxManagerConfig(BaseModel):
             syftbox_folder=syftbox_folder,
             connection_configs=[],  # Empty for in-memory, connections added later
             n_threads=2,  # Use fewer threads for testing
-            ignore_protocol_version=not check_versions,
-            ignore_client_version=not check_versions,
+            force_allow_incompatible_peers=not check_versions,
             has_do_role=has_do_role,
             has_ds_role=has_ds_role,
         )
@@ -353,8 +352,7 @@ class SyftboxManagerConfig(BaseModel):
         peer_manager_config = PeerManagerConfig(
             syftbox_folder=syftbox_folder,
             connection_configs=connection_configs,
-            ignore_protocol_version=not check_versions,
-            ignore_client_version=not check_versions,
+            force_allow_incompatible_peers=not check_versions,
             has_do_role=has_do_role,
             has_ds_role=has_ds_role,
         )
@@ -792,10 +790,13 @@ class SyftboxManager(BaseModel):
         job_name: str = "",
         sync=True,
         force_submission: bool = False,
+        allow_incompatible: bool = False,
     ):
         # Check version compatibility before submission (uses cached versions)
         if not force_submission:
-            self.peer_manager.check_version_for_submission(user, force=False)
+            self.peer_manager.check_version_for_submission(
+                user, force=False, allow_incompatible=allow_incompatible
+            )
         job_dir = self.job_client.submit_bash_job(user, script, job_name=job_name)
         self.push_job_files(job_dir)
 
@@ -808,6 +809,7 @@ class SyftboxManager(BaseModel):
         entrypoint: str | None = None,
         sync=True,
         force_submission: bool = False,
+        allow_incompatible: bool = False,
     ):
         peer_emails = {p.email for p in self.peer_manager.syncable_peers}
         if user not in peer_emails:
@@ -828,7 +830,9 @@ class SyftboxManager(BaseModel):
 
         # Check version compatibility before submission (uses cached versions)
         if not force_submission:
-            self.peer_manager.check_version_for_submission(user, force=False)
+            self.peer_manager.check_version_for_submission(
+                user, force=False, allow_incompatible=allow_incompatible
+            )
         job_dir = self.job_client.submit_python_job(
             user,
             code_path,
@@ -879,6 +883,7 @@ class SyftboxManager(BaseModel):
         auto_compact: bool = True,
         compact_threshold: int = MIN_MESSAGES_COMPACT,
         force_download_peer_state: bool = False,
+        allow_incompatible: bool = False,
     ):
         """
         Sync local state with Google Drive.
@@ -902,7 +907,9 @@ class SyftboxManager(BaseModel):
             if self.has_do_role:
                 peer_emails = [peer.email for peer in self.peer_manager.approved_peers]
                 compatible_emails = self.peer_manager.get_compatible_peer_emails(
-                    peer_emails, warn_incompatible=True
+                    peer_emails,
+                    warn_incompatible=True,
+                    allow_incompatible=allow_incompatible,
                 )
                 self.datasite_owner_syncer.sync(compatible_emails)
                 if auto_compact:
@@ -1007,6 +1014,7 @@ class SyftboxManager(BaseModel):
         force_execution: bool = False,
         share_outputs_with_submitter: bool = False,
         share_logs_with_submitter: bool = False,
+        allow_incompatible: bool = False,
     ) -> None:
         """
         Process approved jobs. Automatically calls sync() after processing
@@ -1028,7 +1036,11 @@ class SyftboxManager(BaseModel):
         skip_job_names = []
 
         if not force_execution:
-            # Check version compatibility for all approved job submitters (uses cached versions)
+            from syft_client.sync.version.version_info import CompatibilityStatus
+
+            effective_allow = (
+                self.peer_manager.force_allow_incompatible_peers or allow_incompatible
+            )
             approved_jobs = [
                 job for job in self.job_client.jobs if job.status == "approved"
             ]
@@ -1037,22 +1049,33 @@ class SyftboxManager(BaseModel):
                 if job.submitted_by == "unknown":
                     continue
 
-                if not self.peer_manager.is_peer_version_compatible(job.submitted_by):
-                    # Warn about incompatible job
-                    peer_version = self.peer_manager.get_peer_version(job.submitted_by)
-                    if peer_version is None:
-                        warnings.warn(
-                            f"Skipping job '{job.name}' from {job.submitted_by}: "
-                            "version unknown. Use force_execution=True to override."
-                        )
-                    else:
-                        own_version = self.peer_manager.get_own_version()
-                        reason = own_version.get_incompatibility_reason(peer_version)
-                        warnings.warn(
-                            f"Skipping job '{job.name}' from {job.submitted_by}: "
-                            f"{reason}. Use force_execution=True to override."
-                        )
-                    skip_job_names.append(job.name)
+                status = self.peer_manager.peer_compatibility_status(job.submitted_by)
+                if status == CompatibilityStatus.SAME:
+                    continue
+                if status == CompatibilityStatus.PATCH_DIFF:
+                    self.peer_manager._emit_patch_warning(job.submitted_by)
+                    continue
+
+                # INCOMPATIBLE or UNKNOWN
+                peer_version = self.peer_manager.get_peer_version(job.submitted_by)
+                if peer_version is None:
+                    detail = "version unknown"
+                else:
+                    own_version = self.peer_manager.get_own_version()
+                    detail = own_version.get_incompatibility_reason(peer_version)
+
+                if effective_allow:
+                    warnings.warn(
+                        f"Proceeding with job '{job.name}' from {job.submitted_by} "
+                        f"despite {detail}."
+                    )
+                    continue
+
+                warnings.warn(
+                    f"Skipping job '{job.name}' from {job.submitted_by}: {detail}. "
+                    "Use force_execution=True or allow_incompatible=True to override."
+                )
+                skip_job_names.append(job.name)
 
         self.job_runner.process_approved_jobs(
             stream_output=stream_output,

--- a/syft_client/sync/version/peer_manager.py
+++ b/syft_client/sync/version/peer_manager.py
@@ -5,6 +5,7 @@ PeerManager for managing peers, version information, and compatibility checks.
 import json
 import warnings
 from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -29,11 +30,58 @@ from syft_client.sync.version.exceptions import (
 from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
 
 
-class JobCompatibilityResult(BaseModel):
-    """Outcome of checking whether an approved job is safe to process."""
+class CompatAction(str, Enum):
+    """What the caller is doing — used to phrase warning messages."""
 
+    SYNC = "sync"
+    SUBMIT = "submit"
+    EXECUTE = "execute"
+
+
+class PeerCompatibilityResult(BaseModel):
+    """Outcome of a per-peer version compatibility check.
+
+    Carries enough context for callers to either warn (`maybe_warn`) or raise
+    (`raise_on_skip`) without re-deriving anything from PeerManager state.
+    """
+
+    peer_email: str
+    status: CompatibilityStatus
     should_skip: bool
-    warning_message: Optional[str] = None
+    action: Optional[CompatAction] = None
+    explanation_skip: Optional[str] = None
+    explanation_not_skip: Optional[str] = None
+    suppress_version_warnings: bool = False
+    local_version: Optional[VersionInfo] = None
+    peer_version: Optional[VersionInfo] = None
+
+    def maybe_warn(self) -> None:
+        """Emit a warning, picking explanation_skip vs explanation_not_skip.
+
+        Appends an override hint only when skipping. Respects
+        suppress_version_warnings.
+        """
+        if self.suppress_version_warnings:
+            return
+        elif self.should_skip:
+            if self.explanation_skip:
+                warnings.warn(
+                    f"{self.explanation_skip} Use ignore_peer_version=True to override."
+                )
+        elif self.explanation_not_skip:
+            warnings.warn(self.explanation_not_skip)
+
+    def raise_on_skip(self, operation: str) -> None:
+        """Raise the appropriate VersionError if `should_skip` is True."""
+        if not self.should_skip:
+            return
+        elif self.status == CompatibilityStatus.UNKNOWN:
+            raise VersionUnknownError(self.peer_email, operation)
+        else:
+            reason = self.explanation_skip or "version mismatch"
+            raise VersionMismatchError(
+                self.peer_email, self.local_version, self.peer_version, reason
+            )
 
 
 class PeerManagerConfig(BaseModel):
@@ -41,7 +89,7 @@ class PeerManagerConfig(BaseModel):
 
     syftbox_folder: Path
     connection_configs: List[ConnectionConfig] = []
-    force_allow_incompatible_peers: bool = False
+    force_ignore_peer_version: bool = False
     suppress_version_warnings: bool = False
     n_threads: int = 10
     has_do_role: bool = False
@@ -57,7 +105,7 @@ class PeerManager(BaseModel):
     syftbox_folder: Path
     connection_router: ConnectionRouter
     peer_store: PeerStore
-    force_allow_incompatible_peers: bool = False
+    force_ignore_peer_version: bool = False
     suppress_version_warnings: bool = False
     n_threads: int = 10
     has_do_role: bool = False
@@ -104,7 +152,7 @@ class PeerManager(BaseModel):
             syftbox_folder=config.syftbox_folder,
             connection_router=connection_router,
             peer_store=peer_store,
-            force_allow_incompatible_peers=config.force_allow_incompatible_peers,
+            force_ignore_peer_version=config.force_ignore_peer_version,
             suppress_version_warnings=config.suppress_version_warnings,
             n_threads=config.n_threads,
             has_do_role=config.has_do_role,
@@ -120,10 +168,6 @@ class PeerManager(BaseModel):
         if self._own_version is None:
             self._own_version = VersionInfo.current()
         return self._own_version
-
-    def read_own_version(self) -> Optional[VersionInfo]:
-        """Read existing version file from own SyftBox folder on Drive."""
-        return self.connection_router.read_own_version_file()
 
     def write_own_version(self) -> None:
         """Write version file to own SyftBox folder (remote) and local disk."""
@@ -205,147 +249,103 @@ class PeerManager(BaseModel):
         status = self.peer_compatibility_status(peer_email)
         return status in (CompatibilityStatus.SAME, CompatibilityStatus.PATCH_DIFF)
 
-    def _emit_patch_warning(self, peer_email: str) -> None:
-        if self.suppress_version_warnings:
-            return
-        peer_version = self.get_peer_version(peer_email)
-        if peer_version is None:
-            return
-        text = self.get_own_version().get_patch_warning_text(peer_version)
-        if text:
-            warnings.warn(f"Peer {peer_email}: {text}")
-
-    def _incompatibility_message(
-        self, peer_email: str, action: str = "Skipping peer"
-    ) -> str:
-        peer_version = self.get_peer_version(peer_email)
-        if peer_version is None:
-            return (
-                f"{action} {peer_email}: version information not available. "
-                "If you are unsure if the version information is up to date, "
-                "call client.sync()."
-            )
-        reason = self.get_own_version().get_incompatibility_reason(peer_version)
-        return f"{action} {peer_email}: {reason}"
-
-    def should_skip_job_for_processing(
+    def get_peer_compatibility_status(
         self,
-        submitted_by: str,
-        job_name: str,
-        allow_incompatible_peer: bool = False,
-    ) -> JobCompatibilityResult:
-        """Decide whether an approved job should be skipped due to version mismatch.
+        peer_email: str,
+        action: CompatAction,
+        ignore_peer_version: bool = False,
+    ) -> PeerCompatibilityResult:
+        """Build a PeerCompatibilityResult describing whether the caller should
+        skip / raise / warn for this peer.
 
-        SAME / unknown-submitter → process silently. PATCH_DIFF → process with a
-        patch warning (unless `suppress_version_warnings`). INCOMPATIBLE / UNKNOWN
-        → skip with warning unless `force_allow_incompatible_peers or
-        allow_incompatible_peer`, in which case process with a "proceeding"
-        warning.
+        SAME → no skip, no warning. PATCH_DIFF → no skip, "patch differs"
+        warning. INCOMPATIBLE / UNKNOWN → skip unless effective
+        `force_ignore_peer_version or ignore_peer_version` (then proceed with
+        a "proceeding to {action}" warning). UNKNOWN's skip message includes
+        a "call client.sync()" hint.
         """
-        if submitted_by == "unknown":
-            return JobCompatibilityResult(should_skip=False)
+        own_version = self.get_own_version()
+        peer_version = self.get_peer_version(peer_email)
+        status = self.peer_compatibility_status(peer_email)
+        common = dict(
+            peer_email=peer_email,
+            status=status,
+            action=action,
+            suppress_version_warnings=self.suppress_version_warnings,
+            local_version=own_version,
+            peer_version=peer_version,
+        )
 
-        status = self.peer_compatibility_status(submitted_by)
         if status == CompatibilityStatus.SAME:
-            return JobCompatibilityResult(should_skip=False)
+            return PeerCompatibilityResult(should_skip=False, **common)
 
         if status == CompatibilityStatus.PATCH_DIFF:
-            warning: Optional[str] = None
-            if not self.suppress_version_warnings:
-                peer_version = self.get_peer_version(submitted_by)
-                if peer_version is not None:
-                    text = self.get_own_version().get_patch_warning_text(peer_version)
-                    if text:
-                        warning = f"Peer {submitted_by}: {text}"
-            return JobCompatibilityResult(should_skip=False, warning_message=warning)
-
-        effective_allow_incompatible_peers = (
-            self.force_allow_incompatible_peers or allow_incompatible_peer
-        )
-        override_hint = (
-            "Use force_execution=True or allow_incompatible_peer=True to override."
-        )
-
-        if status == CompatibilityStatus.UNKNOWN:
-            if effective_allow_incompatible_peers:
-                return JobCompatibilityResult(
-                    should_skip=False,
-                    warning_message=(
-                        f"Proceeding with job '{job_name}' from {submitted_by} "
-                        "despite version unknown."
-                    ),
-                )
-            return JobCompatibilityResult(
-                should_skip=True,
-                warning_message=(
-                    f"Skipping job '{job_name}' from {submitted_by}: "
-                    f"version unknown. {override_hint}"
-                ),
+            patch_text = (
+                own_version.get_patch_warning_text(peer_version)
+                if peer_version is not None
+                else None
+            )
+            explanation_not_skip = (
+                f"Peer {peer_email}: {patch_text}" if patch_text else None
+            )
+            return PeerCompatibilityResult(
+                should_skip=False,
+                explanation_not_skip=explanation_not_skip,
+                **common,
             )
 
-        # INCOMPATIBLE
-        reason = self.get_own_version().get_incompatibility_reason(
-            self.get_peer_version(submitted_by)
-        )
-        if effective_allow_incompatible_peers:
-            return JobCompatibilityResult(
-                should_skip=False,
-                warning_message=(
-                    f"Proceeding with job '{job_name}' from {submitted_by} "
-                    f"despite {reason}."
-                ),
+        # UNKNOWN or INCOMPATIBLE
+        if status == CompatibilityStatus.UNKNOWN:
+            detail = (
+                "version information not available "
+                "(if you are unsure if it is up to date, call client.sync())"
             )
         else:
-            return JobCompatibilityResult(
-                should_skip=True,
-                warning_message=(
-                    f"Skipping job '{job_name}' from {submitted_by}: {reason}. "
-                    f"{override_hint}"
-                ),
-            )
+            detail = own_version.get_incompatibility_reason(peer_version)
 
-    def get_compatible_peer_emails(
+        effective_ignore = self.force_ignore_peer_version or ignore_peer_version
+        if effective_ignore:
+            return PeerCompatibilityResult(
+                should_skip=False,
+                explanation_not_skip=(
+                    f"Proceeding anyway to {action.value} for peer "
+                    f"{peer_email}: {detail}."
+                ),
+                **common,
+            )
+        return PeerCompatibilityResult(
+            should_skip=True,
+            explanation_skip=f"Skipping peer {peer_email}: {detail}.",
+            **common,
+        )
+
+    def get_compatible_peer_emails_for_syncing(
         self,
         peer_emails: List[str],
-        warn_incompatible: bool = True,
-        allow_incompatible: bool = False,
+        ignore_peer_version: bool = False,
     ) -> List[str]:
-        """Filter peer emails to those compatible enough to proceed.
+        """Filter peer emails to those compatible enough to sync with.
 
-        SAME peers are included silently. PATCH_DIFF peers are included with a
-        patch warning. INCOMPATIBLE / UNKNOWN peers are skipped (with a warning)
-        unless effective `force_allow_incompatible_peers or allow_incompatible`,
-        in which case they are included with a "proceeding anyway" warning.
+        Uses `get_peer_compatibility_status` and emits any associated warnings
+        via `PeerCompatibilityResult.maybe_warn()`.
         """
-        effective_allow_incompatible_peers = (
-            self.force_allow_incompatible_peers or allow_incompatible
-        )
         compatible: List[str] = []
         for email in peer_emails:
-            status = self.peer_compatibility_status(email)
-            if status == CompatibilityStatus.SAME:
+            result = self.get_peer_compatibility_status(
+                email,
+                action=CompatAction.SYNC,
+                ignore_peer_version=ignore_peer_version,
+            )
+            result.maybe_warn()
+            if not result.should_skip:
                 compatible.append(email)
-            elif status == CompatibilityStatus.PATCH_DIFF:
-                compatible.append(email)
-                self._emit_patch_warning(email)
-            else:
-                if effective_allow_incompatible_peers:
-                    compatible.append(email)
-                    if warn_incompatible and not self.suppress_version_warnings:
-                        warnings.warn(
-                            self._incompatibility_message(
-                                email, action="Proceeding anyway with peer"
-                            )
-                        )
-                elif warn_incompatible and not self.suppress_version_warnings:
-                    warnings.warn(self._incompatibility_message(email))
         return compatible
 
     def warn_if_all_peers_incompatible(self, peer_emails: List[str]) -> None:
         """Warn if all connected peers are incompatible (used by DS during sync)."""
         if self.suppress_version_warnings:
             return
-        if self.force_allow_incompatible_peers:
+        if self.force_ignore_peer_version:
             return
         if not peer_emails:
             return
@@ -360,79 +360,6 @@ class PeerManager(BaseModel):
                 f"All connected peers ({len(peer_emails)}) have incompatible versions. "
                 "You may not be able to submit jobs or load datasets until versions match."
             )
-
-    def check_version_for_submission(
-        self,
-        peer_email: str,
-        force: bool = False,
-        allow_incompatible: bool = False,
-    ) -> None:
-        """Check version before job submission (DS side).
-
-        SAME → return. PATCH_DIFF → warn, return. INCOMPATIBLE → raise unless
-        effective allow. UNKNOWN → raise unless effective allow.
-
-        Args:
-            peer_email: The DO peer email
-            force: If True, skip version check entirely (hard bypass)
-            allow_incompatible: Per-call override; ORed with
-                `self.force_allow_incompatible_peers`
-
-        Raises:
-            VersionUnknownError: If DO version is unknown and not allowed
-            VersionMismatchError: If versions don't match and not allowed
-        """
-        if force:
-            return
-
-        if self.get_peer_version(peer_email) is None:
-            self.load_peer_version(peer_email)
-
-        self._check_version(peer_email, "submit job", allow_incompatible)
-
-    def check_version_for_job_execution(
-        self, submitter_email: str, allow_incompatible: bool = False
-    ) -> None:
-        """Check version before job execution (DO side)."""
-        self._check_version(submitter_email, "execute job", allow_incompatible)
-
-    def _check_version(
-        self, peer_email: str, operation: str, allow_incompatible: bool
-    ) -> None:
-        effective_allow_incompatible_peers = (
-            self.force_allow_incompatible_peers or allow_incompatible
-        )
-        status = self.peer_compatibility_status(peer_email)
-
-        if status == CompatibilityStatus.SAME:
-            return
-        if status == CompatibilityStatus.PATCH_DIFF:
-            self._emit_patch_warning(peer_email)
-            return
-
-        if status == CompatibilityStatus.UNKNOWN:
-            if effective_allow_incompatible_peers:
-                if not self.suppress_version_warnings:
-                    warnings.warn(
-                        f"Proceeding to {operation} for {peer_email} "
-                        "despite unknown peer version."
-                    )
-                return
-            raise VersionUnknownError(peer_email, operation)
-
-        # INCOMPATIBLE
-        if effective_allow_incompatible_peers:
-            if not self.suppress_version_warnings:
-                warnings.warn(
-                    self._incompatibility_message(
-                        peer_email, action=f"Proceeding to {operation} for"
-                    )
-                )
-            return
-        own_version = self.get_own_version()
-        peer_version = self.get_peer_version(peer_email)
-        reason = own_version.get_incompatibility_reason(peer_version)
-        raise VersionMismatchError(peer_email, own_version, peer_version, reason)
 
     def shutdown(self) -> None:
         """Shutdown the thread pool executor."""

--- a/syft_client/sync/version/peer_manager.py
+++ b/syft_client/sync/version/peer_manager.py
@@ -26,7 +26,7 @@ from syft_client.sync.version.exceptions import (
     VersionMismatchError,
     VersionUnknownError,
 )
-from syft_client.sync.version.version_info import VersionInfo
+from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
 
 
 class PeerManagerConfig(BaseModel):
@@ -34,8 +34,7 @@ class PeerManagerConfig(BaseModel):
 
     syftbox_folder: Path
     connection_configs: List[ConnectionConfig] = []
-    ignore_protocol_version: bool = False
-    ignore_client_version: bool = False
+    force_allow_incompatible_peers: bool = False
     suppress_version_warnings: bool = False
     n_threads: int = 10
     has_do_role: bool = False
@@ -51,8 +50,7 @@ class PeerManager(BaseModel):
     syftbox_folder: Path
     connection_router: ConnectionRouter
     peer_store: PeerStore
-    ignore_protocol_version: bool = False
-    ignore_client_version: bool = False
+    force_allow_incompatible_peers: bool = False
     suppress_version_warnings: bool = False
     n_threads: int = 10
     has_do_role: bool = False
@@ -99,8 +97,7 @@ class PeerManager(BaseModel):
             syftbox_folder=config.syftbox_folder,
             connection_router=connection_router,
             peer_store=peer_store,
-            ignore_protocol_version=config.ignore_protocol_version,
-            ignore_client_version=config.ignore_client_version,
+            force_allow_incompatible_peers=config.force_allow_incompatible_peers,
             suppress_version_warnings=config.suppress_version_warnings,
             n_threads=config.n_threads,
             has_do_role=config.has_do_role,
@@ -166,9 +163,6 @@ class PeerManager(BaseModel):
     ) -> Dict[str, Optional[VersionInfo]]:
         """Load versions for multiple peers in parallel using internal executor."""
 
-        if self.ignore_protocol_version and self.ignore_client_version and not force:
-            return {}
-
         if not peer_emails:
             return {}
 
@@ -194,181 +188,160 @@ class PeerManager(BaseModel):
         if peer:
             peer.version = None
 
+    def peer_compatibility_status(self, peer_email: str) -> CompatibilityStatus:
+        """Get the CompatibilityStatus for a peer (UNKNOWN if version not loaded)."""
+        peer_version = self.get_peer_version(peer_email)
+        return self.get_own_version().compatibility_status_with(peer_version)
+
     def is_peer_version_compatible(self, peer_email: str) -> bool:
-        """
-        Check if peer version is compatible with current client.
+        """True for SAME and PATCH_DIFF; False for INCOMPATIBLE and UNKNOWN."""
+        status = self.peer_compatibility_status(peer_email)
+        return status in (CompatibilityStatus.SAME, CompatibilityStatus.PATCH_DIFF)
 
-        Returns True if:
-        - Both version checks are ignored
-        - Peer version is known and compatible
-        """
-        if self.ignore_protocol_version and self.ignore_client_version:
-            return True
-
+    def _emit_patch_warning(self, peer_email: str) -> None:
+        if self.suppress_version_warnings:
+            return
         peer_version = self.get_peer_version(peer_email)
         if peer_version is None:
-            return False
+            return
+        text = self.get_own_version().get_patch_warning_text(peer_version)
+        if text:
+            warnings.warn(f"Peer {peer_email}: {text}")
 
-        return self.get_own_version().is_compatible_with(
-            peer_version,
-            check_client=not self.ignore_client_version,
-            check_protocol=not self.ignore_protocol_version,
-        )
-
-    def check_version_compatibility(
-        self,
-        peer_email: str,
-        operation: Optional[str] = None,
-        raise_on_mismatch: bool = True,
-        raise_on_unknown: bool = True,
-    ) -> bool:
-        """
-        Check if peer version is compatible.
-
-        Args:
-            peer_email: The peer to check
-            operation: Description of the operation for error messages
-            raise_on_mismatch: Raise VersionMismatchError if incompatible
-            raise_on_unknown: Raise VersionUnknownError if peer version unknown
-
-        Returns:
-            True if compatible, False otherwise
-
-        Raises:
-            VersionUnknownError: If peer version is unknown and raise_on_unknown=True
-            VersionMismatchError: If versions don't match and raise_on_mismatch=True
-        """
-        if self.ignore_protocol_version and self.ignore_client_version:
-            return True
-
+    def _incompatibility_message(
+        self, peer_email: str, action: str = "Skipping peer"
+    ) -> str:
         peer_version = self.get_peer_version(peer_email)
-
         if peer_version is None:
-            if raise_on_unknown:
-                raise VersionUnknownError(peer_email, operation)
-            return False
-
-        own_version = self.get_own_version()
-        is_compatible = own_version.is_compatible_with(
-            peer_version,
-            check_client=not self.ignore_client_version,
-            check_protocol=not self.ignore_protocol_version,
-        )
-
-        if not is_compatible and raise_on_mismatch:
-            reason = own_version.get_incompatibility_reason(
-                peer_version,
-                check_client=not self.ignore_client_version,
-                check_protocol=not self.ignore_protocol_version,
-            )
-            raise VersionMismatchError(peer_email, own_version, peer_version, reason)
-
-        return is_compatible
+            return f"{action} {peer_email}: version information not available."
+        reason = self.get_own_version().get_incompatibility_reason(peer_version)
+        return f"{action} {peer_email}: {reason}"
 
     def get_compatible_peer_emails(
-        self, peer_emails: List[str], warn_incompatible: bool = True
+        self,
+        peer_emails: List[str],
+        warn_incompatible: bool = True,
+        allow_incompatible: bool = False,
     ) -> List[str]:
+        """Filter peer emails to those compatible enough to proceed.
+
+        SAME peers are included silently. PATCH_DIFF peers are included with a
+        patch warning. INCOMPATIBLE / UNKNOWN peers are skipped (with a warning)
+        unless effective `force_allow_incompatible_peers or allow_incompatible`,
+        in which case they are included with a "proceeding anyway" warning.
         """
-        Filter peer emails to only those with compatible versions.
-
-        Args:
-            peer_emails: List of peer emails to filter
-            warn_incompatible: Whether to warn about incompatible peers
-
-        Returns:
-            List of peer emails with compatible versions
-        """
-        if self.ignore_protocol_version and self.ignore_client_version:
-            return peer_emails
-
-        compatible = []
+        effective_allow = self.force_allow_incompatible_peers or allow_incompatible
+        compatible: List[str] = []
         for email in peer_emails:
-            if self.is_peer_version_compatible(email):
+            status = self.peer_compatibility_status(email)
+            if status == CompatibilityStatus.SAME:
                 compatible.append(email)
-            elif warn_incompatible and not self.suppress_version_warnings:
-                peer_version = self.get_peer_version(email)
-                if peer_version is None:
-                    warnings.warn(
-                        f"Skipping peer {email}: version information not available."
-                    )
-                else:
-                    own_version = self.get_own_version()
-                    reason = own_version.get_incompatibility_reason(
-                        peer_version,
-                        check_client=not self.ignore_client_version,
-                        check_protocol=not self.ignore_protocol_version,
-                    )
-                    warnings.warn(f"Skipping peer {email}: {reason}")
-
+            elif status == CompatibilityStatus.PATCH_DIFF:
+                compatible.append(email)
+                self._emit_patch_warning(email)
+            else:
+                if effective_allow:
+                    compatible.append(email)
+                    if warn_incompatible and not self.suppress_version_warnings:
+                        warnings.warn(
+                            self._incompatibility_message(
+                                email, action="Proceeding anyway with peer"
+                            )
+                        )
+                elif warn_incompatible and not self.suppress_version_warnings:
+                    warnings.warn(self._incompatibility_message(email))
         return compatible
 
     def warn_if_all_peers_incompatible(self, peer_emails: List[str]) -> None:
-        """
-        Warn if all connected peers are incompatible (used by DS during sync).
-        """
+        """Warn if all connected peers are incompatible (used by DS during sync)."""
         if self.suppress_version_warnings:
             return
-
-        if self.ignore_protocol_version and self.ignore_client_version:
+        if self.force_allow_incompatible_peers:
             return
-
         if not peer_emails:
             return
 
-        compatible = self.get_compatible_peer_emails(
-            peer_emails, warn_incompatible=False
+        any_compatible = any(
+            self.peer_compatibility_status(email)
+            in (CompatibilityStatus.SAME, CompatibilityStatus.PATCH_DIFF)
+            for email in peer_emails
         )
-        if not compatible:
+        if not any_compatible:
             warnings.warn(
                 f"All connected peers ({len(peer_emails)}) have incompatible versions. "
                 "You may not be able to submit jobs or load datasets until versions match."
             )
 
     def check_version_for_submission(
-        self, peer_email: str, force: bool = False
+        self,
+        peer_email: str,
+        force: bool = False,
+        allow_incompatible: bool = False,
     ) -> None:
-        """
-        Check version before job submission (DS side).
+        """Check version before job submission (DS side).
+
+        SAME → return. PATCH_DIFF → warn, return. INCOMPATIBLE → raise unless
+        effective allow. UNKNOWN → raise unless effective allow.
 
         Args:
             peer_email: The DO peer email
-            force: If True, skip version check
+            force: If True, skip version check entirely (hard bypass)
+            allow_incompatible: Per-call override; ORed with
+                `self.force_allow_incompatible_peers`
 
         Raises:
-            VersionUnknownError: If DO version is unknown
-            VersionMismatchError: If versions don't match
+            VersionUnknownError: If DO version is unknown and not allowed
+            VersionMismatchError: If versions don't match and not allowed
         """
         if force:
             return
 
-        # Load the peer version if not already cached
         if self.get_peer_version(peer_email) is None:
             self.load_peer_version(peer_email)
 
-        self.check_version_compatibility(
-            peer_email,
-            operation="submit job",
-            raise_on_mismatch=True,
-            raise_on_unknown=True,
-        )
+        self._check_version(peer_email, "submit job", allow_incompatible)
 
-    def check_version_for_job_execution(self, submitter_email: str) -> None:
-        """
-        Check version before job execution (DO side).
+    def check_version_for_job_execution(
+        self, submitter_email: str, allow_incompatible: bool = False
+    ) -> None:
+        """Check version before job execution (DO side)."""
+        self._check_version(submitter_email, "execute job", allow_incompatible)
 
-        Args:
-            submitter_email: The DS who submitted the job
+    def _check_version(
+        self, peer_email: str, operation: str, allow_incompatible: bool
+    ) -> None:
+        effective_allow = self.force_allow_incompatible_peers or allow_incompatible
+        status = self.peer_compatibility_status(peer_email)
 
-        Raises:
-            VersionUnknownError: If DS version is unknown
-            VersionMismatchError: If versions don't match
-        """
-        self.check_version_compatibility(
-            submitter_email,
-            operation="execute job",
-            raise_on_mismatch=True,
-            raise_on_unknown=True,
-        )
+        if status == CompatibilityStatus.SAME:
+            return
+        if status == CompatibilityStatus.PATCH_DIFF:
+            self._emit_patch_warning(peer_email)
+            return
+
+        if status == CompatibilityStatus.UNKNOWN:
+            if effective_allow:
+                if not self.suppress_version_warnings:
+                    warnings.warn(
+                        f"Proceeding to {operation} for {peer_email} "
+                        "despite unknown peer version."
+                    )
+                return
+            raise VersionUnknownError(peer_email, operation)
+
+        # INCOMPATIBLE
+        if effective_allow:
+            if not self.suppress_version_warnings:
+                warnings.warn(
+                    self._incompatibility_message(
+                        peer_email, action=f"Proceeding to {operation} for"
+                    )
+                )
+            return
+        own_version = self.get_own_version()
+        peer_version = self.get_peer_version(peer_email)
+        reason = own_version.get_incompatibility_reason(peer_version)
+        raise VersionMismatchError(peer_email, own_version, peer_version, reason)
 
     def shutdown(self) -> None:
         """Shutdown the thread pool executor."""

--- a/syft_client/sync/version/peer_manager.py
+++ b/syft_client/sync/version/peer_manager.py
@@ -90,6 +90,7 @@ class PeerManagerConfig(BaseModel):
     syftbox_folder: Path
     connection_configs: List[ConnectionConfig] = []
     force_ignore_peer_version: bool = False
+    force_ignore_protocol_version: bool = True
     suppress_version_warnings: bool = False
     n_threads: int = 10
     has_do_role: bool = False
@@ -106,6 +107,7 @@ class PeerManager(BaseModel):
     connection_router: ConnectionRouter
     peer_store: PeerStore
     force_ignore_peer_version: bool = False
+    force_ignore_protocol_version: bool = True
     suppress_version_warnings: bool = False
     n_threads: int = 10
     has_do_role: bool = False
@@ -153,6 +155,7 @@ class PeerManager(BaseModel):
             connection_router=connection_router,
             peer_store=peer_store,
             force_ignore_peer_version=config.force_ignore_peer_version,
+            force_ignore_protocol_version=config.force_ignore_protocol_version,
             suppress_version_warnings=config.suppress_version_warnings,
             n_threads=config.n_threads,
             has_do_role=config.has_do_role,

--- a/syft_client/sync/version/version_info.py
+++ b/syft_client/sync/version/version_info.py
@@ -5,6 +5,7 @@ VersionInfo model for representing version information.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -17,6 +18,26 @@ from syft_client.version import (
 )
 
 
+class CompatibilityStatus(str, Enum):
+    """Outcome of comparing two VersionInfo objects."""
+
+    SAME = "same"
+    PATCH_DIFF = "patch_diff"
+    INCOMPATIBLE = "incompatible"
+    UNKNOWN = "unknown"
+
+
+def _parse_semver(version_str: str) -> Optional[tuple[int, int, int]]:
+    """Parse 'X.Y.Z' into (major, minor, patch). Return None if not parseable."""
+    parts = version_str.split(".")
+    if len(parts) < 3:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return None
+
+
 class VersionInfo(BaseModel):
     """Model representing version information for a syft client."""
 
@@ -26,74 +47,51 @@ class VersionInfo(BaseModel):
     min_supported_protocol_version: str
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    def is_compatible_with(
-        self,
-        other: "VersionInfo" | None,
-        check_client: bool = True,
-        check_protocol: bool = True,
-        compatible_if_unknown: bool = False,
-    ) -> bool:
-        """
-        Check if this version is compatible with another version.
-
-        Currently requires exact match for both client and protocol versions.
-        Future: can support range-based compatibility using min_supported_* fields.
-
-        Args:
-            other: The other VersionInfo to check compatibility with
-            check_client: Whether to check client version compatibility
-            check_protocol: Whether to check protocol version compatibility
-
-        Returns:
-            True if versions are compatible, False otherwise
-        """
+    def compatibility_status_with(
+        self, other: "VersionInfo" | None
+    ) -> CompatibilityStatus:
+        """Compare syft_client_version against another VersionInfo."""
         if other is None:
-            return compatible_if_unknown
+            return CompatibilityStatus.UNKNOWN
 
-        if check_protocol:
-            if self.protocol_version != other.protocol_version:
-                return False
+        if self.syft_client_version == other.syft_client_version:
+            return CompatibilityStatus.SAME
 
-        if check_client:
-            if self.syft_client_version != other.syft_client_version:
-                return False
+        local = _parse_semver(self.syft_client_version)
+        peer = _parse_semver(other.syft_client_version)
+        if local is None or peer is None:
+            return CompatibilityStatus.INCOMPATIBLE
 
-        return True
+        if local[0] == peer[0] and local[1] == peer[1]:
+            return CompatibilityStatus.PATCH_DIFF
 
-    def get_incompatibility_reason(
-        self,
-        other: "VersionInfo",
-        check_client: bool = True,
-        check_protocol: bool = True,
-    ) -> Optional[str]:
-        """
-        Get the reason why two versions are incompatible.
+        return CompatibilityStatus.INCOMPATIBLE
 
-        Args:
-            other: The other VersionInfo to check compatibility with
-            check_client: Whether to check client version compatibility
-            check_protocol: Whether to check protocol version compatibility
+    def is_compatible_with(self, other: "VersionInfo" | None) -> bool:
+        """True if SAME or PATCH_DIFF (patch differences are non-blocking)."""
+        status = self.compatibility_status_with(other)
+        return status in (CompatibilityStatus.SAME, CompatibilityStatus.PATCH_DIFF)
 
-        Returns:
-            A string describing the incompatibility, or None if compatible
-        """
-        reasons = []
+    def get_incompatibility_reason(self, other: "VersionInfo") -> Optional[str]:
+        """Reason string when minor/major mismatch; None for SAME or PATCH_DIFF."""
+        status = self.compatibility_status_with(other)
+        if status in (CompatibilityStatus.SAME, CompatibilityStatus.PATCH_DIFF):
+            return None
+        return (
+            f"Client version mismatch (minor or major): "
+            f"local={self.syft_client_version}, peer={other.syft_client_version}"
+        )
 
-        if check_protocol and self.protocol_version != other.protocol_version:
-            reasons.append(
-                f"Protocol version mismatch: local={self.protocol_version}, "
-                f"peer={other.protocol_version}"
-            )
-
-        if check_client and self.syft_client_version != other.syft_client_version:
-            reasons.append(
-                f"Client version mismatch: local={self.syft_client_version}, "
-                f"peer={other.syft_client_version}"
-            )
-
-        if reasons:
-            return "; ".join(reasons)
-        return None
+    def get_patch_warning_text(self, other: "VersionInfo") -> Optional[str]:
+        """Warning string when only patch versions differ."""
+        status = self.compatibility_status_with(other)
+        if status != CompatibilityStatus.PATCH_DIFF:
+            return None
+        return (
+            f"Client version differs by patch only: "
+            f"local={self.syft_client_version}, peer={other.syft_client_version} "
+            f"— proceeding"
+        )
 
     @classmethod
     def current(cls) -> "VersionInfo":

--- a/tests/unit/test_version_negotiation.py
+++ b/tests/unit/test_version_negotiation.py
@@ -1,18 +1,32 @@
 """Unit tests for version negotiation feature."""
 
+import warnings
+
 import pytest
 from syft_client.sync.syftbox_manager import SyftboxManager
-from syft_client.sync.version.version_info import VersionInfo
 from syft_client.sync.version.exceptions import (
+    VersionMismatchError,
     VersionUnknownError,
 )
+from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
+
+
+def _v(client_version: str) -> VersionInfo:
+    """Build a VersionInfo for a given client version, leaving other fields as-current."""
+    base = VersionInfo.current()
+    return VersionInfo(
+        syft_client_version=client_version,
+        min_supported_syft_client_version=base.min_supported_syft_client_version,
+        protocol_version=base.protocol_version,
+        min_supported_protocol_version=base.min_supported_protocol_version,
+        updated_at=base.updated_at,
+    )
 
 
 class TestVersionInfo:
     """Tests for VersionInfo model."""
 
     def test_current_version_creates_valid_info(self):
-        """Test that VersionInfo.current() creates valid version info."""
         version_info = VersionInfo.current()
         assert version_info.syft_client_version is not None
         assert version_info.protocol_version is not None
@@ -21,7 +35,6 @@ class TestVersionInfo:
         assert version_info.updated_at is not None
 
     def test_version_info_json_roundtrip(self):
-        """Test that VersionInfo can be serialized and deserialized."""
         original = VersionInfo.current()
         json_str = original.to_json()
         restored = VersionInfo.from_json(json_str)
@@ -38,186 +51,165 @@ class TestVersionInfo:
         )
 
     def test_compatible_versions_match(self):
-        """Test that identical versions are compatible."""
         v1 = VersionInfo.current()
         v2 = VersionInfo.current()
-
         assert v1.is_compatible_with(v2) is True
         assert v2.is_compatible_with(v1) is True
 
-    def test_incompatible_client_version(self):
-        """Test that different client versions are incompatible."""
-        v1 = VersionInfo.current()
-        v2 = VersionInfo(
-            syft_client_version="0.0.1",  # Different version
-            min_supported_syft_client_version=v1.min_supported_syft_client_version,
-            protocol_version=v1.protocol_version,
-            min_supported_protocol_version=v1.min_supported_protocol_version,
-            updated_at=v1.updated_at,
+    def test_minor_version_mismatch_is_incompatible(self):
+        v1 = _v("0.1.113")
+        v2 = _v("0.0.1")
+        assert v1.is_compatible_with(v2) is False
+
+    def test_protocol_only_diff_is_compatible_now(self):
+        """Protocol_version differences alone no longer block compatibility."""
+        base = VersionInfo.current()
+        v_diff_protocol = VersionInfo(
+            syft_client_version=base.syft_client_version,
+            min_supported_syft_client_version=base.min_supported_syft_client_version,
+            protocol_version="0.0.1",
+            min_supported_protocol_version=base.min_supported_protocol_version,
+            updated_at=base.updated_at,
         )
-
-        assert v1.is_compatible_with(v2, check_client=True) is False
-        assert v1.is_compatible_with(v2, check_client=False) is True
-
-    def test_incompatible_protocol_version(self):
-        """Test that different protocol versions are incompatible."""
-        v1 = VersionInfo.current()
-        v2 = VersionInfo(
-            syft_client_version=v1.syft_client_version,
-            min_supported_syft_client_version=v1.min_supported_syft_client_version,
-            protocol_version="0.0.1",  # Different version
-            min_supported_protocol_version=v1.min_supported_protocol_version,
-            updated_at=v1.updated_at,
-        )
-
-        assert v1.is_compatible_with(v2, check_protocol=True) is False
-        assert v1.is_compatible_with(v2, check_protocol=False) is True
+        assert base.is_compatible_with(v_diff_protocol) is True
 
     def test_get_incompatibility_reason_client(self):
-        """Test that incompatibility reason is returned for client version mismatch."""
-        v1 = VersionInfo.current()
-        v2 = VersionInfo(
-            syft_client_version="0.0.1",
-            min_supported_syft_client_version=v1.min_supported_syft_client_version,
-            protocol_version=v1.protocol_version,
-            min_supported_protocol_version=v1.min_supported_protocol_version,
-            updated_at=v1.updated_at,
-        )
-
-        reason = v1.get_incompatibility_reason(v2, check_client=True)
+        v1 = _v("0.1.113")
+        v2 = _v("0.0.1")
+        reason = v1.get_incompatibility_reason(v2)
         assert reason is not None
         assert "client" in reason.lower()
 
-    def test_get_incompatibility_reason_protocol(self):
-        """Test that incompatibility reason is returned for protocol version mismatch."""
-        v1 = VersionInfo.current()
-        v2 = VersionInfo(
-            syft_client_version=v1.syft_client_version,
-            min_supported_syft_client_version=v1.min_supported_syft_client_version,
-            protocol_version="0.0.1",
-            min_supported_protocol_version=v1.min_supported_protocol_version,
-            updated_at=v1.updated_at,
+
+class TestCompatibilityStatus:
+    """Tests for CompatibilityStatus enum and compatibility_status_with."""
+
+    def test_same_version(self):
+        assert _v("0.1.113").compatibility_status_with(_v("0.1.113")) == (
+            CompatibilityStatus.SAME
         )
 
-        reason = v1.get_incompatibility_reason(v2, check_protocol=True)
-        assert reason is not None
-        assert "protocol" in reason.lower()
+    def test_patch_diff(self):
+        assert _v("0.1.113").compatibility_status_with(_v("0.1.114")) == (
+            CompatibilityStatus.PATCH_DIFF
+        )
+
+    def test_minor_diff_is_incompatible(self):
+        assert _v("0.1.113").compatibility_status_with(_v("0.2.0")) == (
+            CompatibilityStatus.INCOMPATIBLE
+        )
+
+    def test_major_diff_is_incompatible(self):
+        assert _v("0.1.113").compatibility_status_with(_v("1.0.0")) == (
+            CompatibilityStatus.INCOMPATIBLE
+        )
+
+    def test_unknown_when_other_none(self):
+        assert _v("0.1.113").compatibility_status_with(None) == (
+            CompatibilityStatus.UNKNOWN
+        )
+
+    def test_patch_warning_text_only_for_patch_diff(self):
+        assert _v("0.1.113").get_patch_warning_text(_v("0.1.113")) is None
+        assert _v("0.1.113").get_patch_warning_text(_v("0.2.0")) is None
+        warning = _v("0.1.113").get_patch_warning_text(_v("0.1.114"))
+        assert warning is not None
+        assert "0.1.113" in warning and "0.1.114" in warning
+
+    def test_is_compatible_with_includes_patch_diff(self):
+        assert _v("0.1.113").is_compatible_with(_v("0.1.114")) is True
+        assert _v("0.1.113").is_compatible_with(_v("0.2.0")) is False
+        assert _v("0.1.113").is_compatible_with(None) is False
 
 
 class TestPeerManager:
     """Tests for PeerManager."""
 
     def test_peer_manager_writes_own_version(self):
-        """Test that PeerManager writes version file on initialization."""
         ds_manager, do_manager = (
             SyftboxManager.pair_with_mock_drive_service_connection()
         )
 
-        # Version should be written during initialization - verify via public API
-        # DS can read DO's version after peer setup (they're auto-added as peers)
         ds_version = do_manager.peer_manager.load_peer_version(ds_manager.email)
         do_version = ds_manager.peer_manager.load_peer_version(do_manager.email)
 
-        assert ds_version is not None, "DS version should be readable by DO"
-        assert do_version is not None, "DO version should be readable by DS"
+        assert ds_version is not None
+        assert do_version is not None
 
     def test_version_shared_on_add_peer(self):
-        """Test that version file is shared when adding a peer."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             add_peers=False
         )
 
-        # Before adding peer, DO cannot read DS's version
         ds_version_before = do_manager.peer_manager.load_peer_version(ds_manager.email)
-        assert ds_version_before is None, "DO should not be able to read DS version yet"
+        assert ds_version_before is None
 
-        # DS adds DO as peer
         ds_manager.add_peer(do_manager.email)
 
-        # Now DO should be able to read DS's version (shared on add_peer)
         ds_version_after = do_manager.peer_manager.load_peer_version(ds_manager.email)
-        assert ds_version_after is not None, (
-            "DO should be able to read DS version after add_peer"
-        )
+        assert ds_version_after is not None
 
     def test_version_shared_on_approve_peer(self):
-        """Test that version file is shared when approving a peer request."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             add_peers=False
         )
 
-        # DS adds DO as peer (creates pending request)
         ds_manager.add_peer(do_manager.email)
         do_manager.load_peers()
 
-        # Before approval, DS cannot read DO's version
         do_version_before = ds_manager.peer_manager.load_peer_version(do_manager.email)
-        assert do_version_before is None, (
-            "DS should not be able to read DO version before approval"
-        )
+        assert do_version_before is None
 
-        # DO approves DS
         do_manager.approve_peer_request(ds_manager.email)
 
-        # Now DS should be able to read DO's version (shared on approve)
         do_version_after = ds_manager.peer_manager.load_peer_version(do_manager.email)
-        assert do_version_after is not None, (
-            "DS should be able to read DO version after approval"
-        )
+        assert do_version_after is not None
 
     def test_load_peer_version(self):
-        """Test that peer version can be loaded."""
         ds_manager, do_manager = (
             SyftboxManager.pair_with_mock_drive_service_connection()
         )
 
-        # DS should be able to load DO's version
         version = ds_manager.peer_manager.load_peer_version(do_manager.email)
         assert version is not None
         assert version.syft_client_version == VersionInfo.current().syft_client_version
 
     def test_load_peer_version_without_permission(self):
-        """Test that peer version returns None without permission."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             add_peers=False
         )
 
-        # DS tries to load DO's version without having permission
         version = ds_manager.peer_manager.load_peer_version(do_manager.email)
         assert version is None
 
     def test_load_peer_versions_parallel(self):
-        """Test that multiple peer versions can be loaded in parallel."""
+        from syft_client.sync.connections.drive.gdrive_transport import (
+            SYFT_VERSION_FILE,
+        )
         from syft_client.sync.connections.drive.mock_drive_service import (
             MockDriveFile,
             MockPermission,
-        )
-        from syft_client.sync.connections.drive.gdrive_transport import (
-            SYFT_VERSION_FILE,
         )
 
         ds_manager, do_manager = (
             SyftboxManager.pair_with_mock_drive_service_connection()
         )
 
-        # Get the backing store to manually insert a version file for a third peer
         backing_store = ds_manager._connection_router.connections[
             0
         ].drive_service._backing_store
 
-        # Create a version file for a third peer manually in the backing store
         third_peer_email = "third_peer@test.com"
         third_peer_version = VersionInfo.current()
         version_file = MockDriveFile(
             name=SYFT_VERSION_FILE,
             mimeType="application/json",
-            parents=[],  # Root level, owned by third peer
+            parents=[],
             owners=[{"emailAddress": third_peer_email}],
             content=third_peer_version.to_json(),
         )
         backing_store.add_file(version_file)
 
-        # Share the version file with DS (add read permission)
         backing_store.add_permission(
             version_file.id,
             MockPermission(
@@ -227,7 +219,6 @@ class TestPeerManager:
             ),
         )
 
-        # Load peer versions for both DO and the third peer in parallel
         peer_emails = [do_manager.email, third_peer_email]
         versions = ds_manager.peer_manager.load_peer_versions_parallel(
             peer_emails, force=True
@@ -246,21 +237,18 @@ class TestForceSubmission:
     """Tests for force_submission parameter."""
 
     def test_job_submission_blocked_without_version(self):
-        """Test that job submission is blocked when peer version is unknown."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             add_peers=False,
             sync_automatically=False,
             check_versions=True,
         )
 
-        # DS adds DO but DO hasn't shared version with DS yet
         ds_manager.add_peer(do_manager.email)
 
         test_py_path = "/tmp/test_version.py"
         with open(test_py_path, "w") as f:
             f.write('print("hello")')
 
-        # Should raise because DO version is unknown to DS
         with pytest.raises(VersionUnknownError):
             ds_manager.submit_python_job(
                 user=do_manager.email,
@@ -269,22 +257,18 @@ class TestForceSubmission:
             )
 
     def test_job_submission_allowed_with_force(self):
-        """Test that job submission works with force_submission=True when version is unknown."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             add_peers=False,
             sync_automatically=False,
             check_versions=True,
         )
 
-        # DS adds DO as peer but DO hasn't approved yet
-        # (so DO's version file isn't shared with DS)
         ds_manager.add_peer(do_manager.email)
 
         test_py_path = "/tmp/test_version_force.py"
         with open(test_py_path, "w") as f:
             f.write('print("hello")')
 
-        # Without force, should fail because version is unknown
         with pytest.raises(VersionUnknownError):
             ds_manager.submit_python_job(
                 user=do_manager.email,
@@ -292,15 +276,12 @@ class TestForceSubmission:
                 job_name="test.fail.job",
             )
 
-        # Should work with force_submission=True (doesn't check version)
-        # Note: job won't sync to DO since peer not approved, but submission succeeds
         ds_manager.submit_python_job(
             user=do_manager.email,
             code_path=test_py_path,
             job_name="test.force.job",
             force_submission=True,
         )
-        # Verify job files were created (submission succeeded)
 
         job_dir = (
             ds_manager.syftbox_folder
@@ -311,201 +292,144 @@ class TestForceSubmission:
             / ds_manager.email
             / "test.force.job"
         )
-        assert job_dir.exists(), "Job directory should exist after force submission"
+        assert job_dir.exists()
 
 
-class TestIgnoreVersionFlags:
-    """Tests for ignore_protocol_version and ignore_client_version flags."""
+def _set_peer_version(manager: SyftboxManager, peer_email: str, version: VersionInfo):
+    """Override the cached version for a peer without a Drive round-trip."""
+    peer = manager.peer_manager.get_cached_peer(peer_email)
+    assert peer is not None, f"peer {peer_email} not in store"
+    peer.version = version
 
-    def test_ignore_client_version(self):
-        """Test that ignore_client_version bypasses client version check."""
-        ds_manager, do_manager = (
-            SyftboxManager.pair_with_mock_drive_service_connection()
+
+class TestPatchTolerance:
+    """Tests that patch-only differences warn but don't block."""
+
+    def test_patch_diff_does_not_skip_in_sync(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
         )
 
-        # Write an incompatible client version for DO using public API
         current = VersionInfo.current()
-        different_version = VersionInfo(
-            syft_client_version="0.0.1",  # Different
-            min_supported_syft_client_version=current.min_supported_syft_client_version,
-            protocol_version=current.protocol_version,
-            min_supported_protocol_version=current.min_supported_protocol_version,
-            updated_at=current.updated_at,
+        major, minor, patch = (
+            int(current.syft_client_version.split(".")[0]),
+            int(current.syft_client_version.split(".")[1]),
+            int(current.syft_client_version.split(".")[2]),
         )
-        do_manager._connection_router.write_version_file(different_version)
+        patch_diff_version = _v(f"{major}.{minor}.{patch + 1}")
+        _set_peer_version(do_manager, ds_manager.email, patch_diff_version)
 
-        # Clear DS's cached version of DO and reload
-        ds_manager.peer_manager.clear_peer_version(do_manager.email)
-        ds_manager.peer_manager.load_peer_version(do_manager.email)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            compatible = do_manager.peer_manager.get_compatible_peer_emails(
+                [ds_manager.email]
+            )
+        assert ds_manager.email in compatible
+        assert any("patch" in str(w.message).lower() for w in caught)
 
-        # Without ignore flag, should be incompatible
-        ds_manager.peer_manager.ignore_client_version = False
-        assert not ds_manager.peer_manager.is_peer_version_compatible(do_manager.email)
-
-        # With ignore flag, should be compatible
-        ds_manager.peer_manager.ignore_client_version = True
-        assert ds_manager.peer_manager.is_peer_version_compatible(do_manager.email)
-
-    def test_ignore_protocol_version(self):
-        """Test that ignore_protocol_version bypasses protocol version check."""
-        ds_manager, do_manager = (
-            SyftboxManager.pair_with_mock_drive_service_connection()
+    def test_patch_diff_allows_job_submission(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
         )
 
-        # Write an incompatible protocol version for DO using public API
         current = VersionInfo.current()
-        different_version = VersionInfo(
-            syft_client_version=current.syft_client_version,
-            min_supported_syft_client_version=current.min_supported_syft_client_version,
-            protocol_version="0.0.1",  # Different
-            min_supported_protocol_version=current.min_supported_protocol_version,
-            updated_at=current.updated_at,
+        parts = current.syft_client_version.split(".")
+        patch_diff_version = _v(f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}")
+        _set_peer_version(ds_manager, do_manager.email, patch_diff_version)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ds_manager.peer_manager.check_version_for_submission(do_manager.email)
+        assert any("patch" in str(w.message).lower() for w in caught)
+
+
+class TestForceAllowIncompatiblePeers:
+    """Tests for force_allow_incompatible_peers and per-call allow_incompatible."""
+
+    def test_incompatible_peer_skipped_by_default(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
         )
-        do_manager._connection_router.write_version_file(different_version)
+        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
 
-        # Clear DS's cached version of DO and reload
-        ds_manager.peer_manager.clear_peer_version(do_manager.email)
-        ds_manager.peer_manager.load_peer_version(do_manager.email)
+        do_manager.peer_manager.suppress_version_warnings = True
+        compatible = do_manager.peer_manager.get_compatible_peer_emails(
+            [ds_manager.email]
+        )
+        assert ds_manager.email not in compatible
 
-        # Without ignore flag, should be incompatible
-        ds_manager.peer_manager.ignore_protocol_version = False
-        assert (
-            ds_manager.peer_manager.is_peer_version_compatible(do_manager.email)
-            is False
+    def test_force_allow_includes_incompatible_peer(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
+        )
+        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
+
+        do_manager.peer_manager.force_allow_incompatible_peers = True
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            compatible = do_manager.peer_manager.get_compatible_peer_emails(
+                [ds_manager.email]
+            )
+        assert ds_manager.email in compatible
+        assert any("proceeding anyway" in str(w.message).lower() for w in caught)
+
+    def test_per_call_allow_incompatible_includes_peer(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
+        )
+        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
+
+        compatible = do_manager.peer_manager.get_compatible_peer_emails(
+            [ds_manager.email], allow_incompatible=True
+        )
+        assert ds_manager.email in compatible
+
+    def test_per_call_allow_incompatible_in_submit(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
+        )
+        _set_peer_version(ds_manager, do_manager.email, _v("99.0.0"))
+
+        with pytest.raises(VersionMismatchError):
+            ds_manager.peer_manager.check_version_for_submission(do_manager.email)
+
+        # With per-call override, should not raise
+        ds_manager.peer_manager.check_version_for_submission(
+            do_manager.email, allow_incompatible=True
         )
 
-        # With ignore flag, should be compatible
-        ds_manager.peer_manager.ignore_protocol_version = True
-        assert (
-            ds_manager.peer_manager.is_peer_version_compatible(do_manager.email) is True
+    def test_force_allow_in_submit(self):
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
         )
+        _set_peer_version(ds_manager, do_manager.email, _v("99.0.0"))
 
-    def test_ignore_both_versions(self):
-        """Test that ignoring both versions makes any peer compatible."""
-        ds_manager, do_manager = (
-            SyftboxManager.pair_with_mock_drive_service_connection()
-        )
-
-        # Write completely different versions for DO using public API
-        current = VersionInfo.current()
-        different_version = VersionInfo(
-            syft_client_version="0.0.1",
-            min_supported_syft_client_version="0.0.1",
-            protocol_version="0.0.1",
-            min_supported_protocol_version="0.0.1",
-            updated_at=current.updated_at,
-        )
-        do_manager._connection_router.write_version_file(different_version)
-
-        # Clear DS's cached version and reload
-        ds_manager.peer_manager.clear_peer_version(do_manager.email)
-        ds_manager.peer_manager.ignore_client_version = True
-        ds_manager.peer_manager.ignore_protocol_version = True
-        ds_manager.peer_manager.load_peer_version(do_manager.email)
-
-        assert (
-            ds_manager.peer_manager.is_peer_version_compatible(do_manager.email) is True
-        )
+        ds_manager.peer_manager.force_allow_incompatible_peers = True
+        # Should not raise
+        ds_manager.peer_manager.check_version_for_submission(do_manager.email)
 
 
 class TestVersionMismatchBehavior:
     """Tests for version mismatch behavior during operations."""
 
     def test_sync_skips_incompatible_peers(self):
-        """Test that sync skips peers with incompatible versions (DO side)."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
+        _set_peer_version(do_manager, ds_manager.email, _v("0.0.1"))
 
-        # Write an incompatible version for DS using public API
-        current = VersionInfo.current()
-        incompatible = VersionInfo(
-            syft_client_version="0.0.1",
-            min_supported_syft_client_version=current.min_supported_syft_client_version,
-            protocol_version=current.protocol_version,
-            min_supported_protocol_version=current.min_supported_protocol_version,
-            updated_at=current.updated_at,
-        )
-        ds_manager._connection_router.write_version_file(incompatible)
-
-        # Clear cached version so it sees the incompatible version
-        do_manager.peer_manager.clear_peer_version(ds_manager.email)
-        do_manager.peer_manager.load_peer_version(ds_manager.email)
-
-        # DO loads peers and syncs - should skip DS due to version mismatch
-        do_manager.load_peers()
         do_manager.peer_manager.suppress_version_warnings = True
-
         compatible_peers = do_manager.peer_manager.get_compatible_peer_emails(
             [ds_manager.email], warn_incompatible=False
         )
-
         assert ds_manager.email not in compatible_peers
 
-    @pytest.mark.skip(
-        reason="skip_job_names parameter not in installed syft-job package"
-    )
-    def test_job_execution_skipped_with_incompatible_version(self):
-        """Test that job execution is skipped (with warning) when submitter version is incompatible."""
-        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
-            sync_automatically=False,
-            use_in_memory_cache=False,
-            check_versions=True,
-        )
-
-        # Submit a job first (with compatible versions)
-        test_py_path = "/tmp/test_exec.py"
-        with open(test_py_path, "w") as f:
-            f.write('print("hello")')
-
-        ds_manager.submit_python_job(
-            user=do_manager.email,
-            code_path=test_py_path,
-            job_name="test.exec.job",
-        )
-
-        do_manager.sync()
-        assert len(do_manager.job_client.jobs) == 1
-        job = do_manager.job_client.jobs[0]
-        job.approve()
-
-        # Now change DS version to be incompatible using public API
-        current = VersionInfo.current()
-        incompatible = VersionInfo(
-            syft_client_version="0.0.1",
-            min_supported_syft_client_version=current.min_supported_syft_client_version,
-            protocol_version=current.protocol_version,
-            min_supported_protocol_version=current.min_supported_protocol_version,
-            updated_at=current.updated_at,
-        )
-        ds_manager._connection_router.write_version_file(incompatible)
-
-        # Clear cached version so it sees the incompatible version
-        do_manager.peer_manager.clear_peer_version(ds_manager.email)
-        do_manager.peer_manager.load_peer_version(ds_manager.email)
-
-        # Job execution should be skipped (with warning) due to version mismatch
-        # Job remains approved but is not executed
-        import warnings
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            do_manager.process_approved_jobs()
-            # Check that a warning was issued about skipping the job
-            assert len(w) >= 1
-            assert any("Skipping job" in str(warning.message) for warning in w)
-
-        # Job should still be approved (not executed, not rejected)
-        assert job.status == "approved"
-
     def test_job_execution_forced_with_incompatible_version(self):
-        """Test that job execution can be forced even when submitter version is incompatible."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             sync_automatically=False,
             use_in_memory_cache=False,
         )
 
-        # Submit a job first (with compatible versions)
         test_py_path = "/tmp/test_exec_force.py"
         with open(test_py_path, "w") as f:
             f.write('print("hello")')
@@ -521,90 +445,34 @@ class TestVersionMismatchBehavior:
         job = do_manager.job_client.jobs[0]
         job.approve()
 
-        # Now change DS version to be incompatible using public API
-        current = VersionInfo.current()
-        incompatible = VersionInfo(
-            syft_client_version="0.0.1",
-            min_supported_syft_client_version=current.min_supported_syft_client_version,
-            protocol_version=current.protocol_version,
-            min_supported_protocol_version=current.min_supported_protocol_version,
-            updated_at=current.updated_at,
-        )
-        ds_manager._connection_router.write_version_file(incompatible)
+        _set_peer_version(do_manager, ds_manager.email, _v("0.0.1"))
 
-        # Clear cached version so it sees the incompatible version
-        do_manager.peer_manager.clear_peer_version(ds_manager.email)
-        do_manager.peer_manager.load_peer_version(ds_manager.email)
-
-        # Mock the job_runner to avoid actual execution
         executed_jobs = []
 
         def mock_process_approved_jobs(
             stream_output=True, timeout=None, skip_job_names=None, **kwargs
         ):
-            # Track that we were called without skip_job_names (force mode)
             executed_jobs.append(skip_job_names)
 
         do_manager.job_runner.process_approved_jobs = mock_process_approved_jobs
 
-        # With force_execution=True, job_runner should be called without skip list
         do_manager.process_approved_jobs(force_execution=True)
 
-        # Verify job_runner was called with no jobs to skip
         assert len(executed_jobs) == 1
         assert executed_jobs[0] is None  # No jobs skipped when force=True
 
     def test_version_upgrade_breaks_communication(self):
-        """Test that version upgrade makes peers incompatible.
-
-        Unit test equivalent of integration test_version_upgrade_breaks_communication.
-
-        1. Initialize peers with matching versions and verify they are compatible
-        2. Update one peer's version (simulating an upgrade)
-        3. Reload the version and verify peers are now incompatible
-        """
-        # Phase 1: Create managers with compatible versions
+        """Major-bump upgrade should now make peers incompatible."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
 
-        # Verify initial version compatibility
         ds_manager.peer_manager.load_peer_version(do_manager.email)
         do_manager.peer_manager.load_peer_version(ds_manager.email)
 
-        assert ds_manager.peer_manager.is_peer_version_compatible(do_manager.email), (
-            "DS should see DO as compatible initially"
-        )
-        assert do_manager.peer_manager.is_peer_version_compatible(ds_manager.email), (
-            "DO should see DS as compatible initially"
-        )
+        assert ds_manager.peer_manager.is_peer_version_compatible(do_manager.email)
+        assert do_manager.peer_manager.is_peer_version_compatible(ds_manager.email)
 
-        # Phase 2: Simulate DS "upgrading" to a new incompatible version
-        current = VersionInfo.current()
-        new_version = VersionInfo(
-            syft_client_version="99.0.0",  # Incompatible version
-            min_supported_syft_client_version="99.0.0",
-            protocol_version=current.protocol_version,
-            min_supported_protocol_version=current.min_supported_protocol_version,
-            updated_at=current.updated_at,
-        )
+        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
 
-        # Write the new version using public API (simulating DS upgrading their client)
-        ds_manager._connection_router.write_version_file(new_version)
-
-        # Phase 3: Clear DO's cached version of DS and reload
-        do_manager.peer_manager.clear_peer_version(ds_manager.email)
-
-        # Reload DS's version
-        reloaded_version = do_manager.peer_manager.load_peer_version(ds_manager.email)
-
-        # Verify the new version was loaded
-        assert reloaded_version is not None, "Should be able to reload peer version"
-        assert reloaded_version.syft_client_version == "99.0.0", (
-            "Reloaded version should be the upgraded version"
-        )
-
-        # Verify versions are now incompatible
-        assert not do_manager.peer_manager.is_peer_version_compatible(
-            ds_manager.email
-        ), "DO should now see DS as incompatible after version upgrade"
+        assert not do_manager.peer_manager.is_peer_version_compatible(ds_manager.email)

--- a/tests/unit/test_version_negotiation.py
+++ b/tests/unit/test_version_negotiation.py
@@ -8,10 +8,11 @@ from syft_client.sync.version.exceptions import (
     VersionMismatchError,
     VersionUnknownError,
 )
+from syft_client.sync.version.peer_manager import CompatAction
 from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
 
 
-def _v(client_version: str) -> VersionInfo:
+def build_client_version(client_version: str) -> VersionInfo:
     """Build a VersionInfo for a given client version, leaving other fields as-current."""
     base = VersionInfo.current()
     return VersionInfo(
@@ -57,8 +58,8 @@ class TestVersionInfo:
         assert v2.is_compatible_with(v1) is True
 
     def test_minor_version_mismatch_is_incompatible(self):
-        v1 = _v("0.1.113")
-        v2 = _v("0.0.1")
+        v1 = build_client_version("0.1.113")
+        v2 = build_client_version("0.0.1")
         assert v1.is_compatible_with(v2) is False
 
     def test_protocol_only_diff_is_compatible_now(self):
@@ -74,8 +75,8 @@ class TestVersionInfo:
         assert base.is_compatible_with(v_diff_protocol) is True
 
     def test_get_incompatibility_reason_client(self):
-        v1 = _v("0.1.113")
-        v2 = _v("0.0.1")
+        v1 = build_client_version("0.1.113")
+        v2 = build_client_version("0.0.1")
         reason = v1.get_incompatibility_reason(v2)
         assert reason is not None
         assert "client" in reason.lower()
@@ -85,41 +86,63 @@ class TestCompatibilityStatus:
     """Tests for CompatibilityStatus enum and compatibility_status_with."""
 
     def test_same_version(self):
-        assert _v("0.1.113").compatibility_status_with(_v("0.1.113")) == (
-            CompatibilityStatus.SAME
-        )
+        assert build_client_version("0.1.113").compatibility_status_with(
+            build_client_version("0.1.113")
+        ) == (CompatibilityStatus.SAME)
 
     def test_patch_diff(self):
-        assert _v("0.1.113").compatibility_status_with(_v("0.1.114")) == (
-            CompatibilityStatus.PATCH_DIFF
-        )
+        assert build_client_version("0.1.113").compatibility_status_with(
+            build_client_version("0.1.114")
+        ) == (CompatibilityStatus.PATCH_DIFF)
 
     def test_minor_diff_is_incompatible(self):
-        assert _v("0.1.113").compatibility_status_with(_v("0.2.0")) == (
-            CompatibilityStatus.INCOMPATIBLE
-        )
+        assert build_client_version("0.1.113").compatibility_status_with(
+            build_client_version("0.2.0")
+        ) == (CompatibilityStatus.INCOMPATIBLE)
 
     def test_major_diff_is_incompatible(self):
-        assert _v("0.1.113").compatibility_status_with(_v("1.0.0")) == (
-            CompatibilityStatus.INCOMPATIBLE
-        )
+        assert build_client_version("0.1.113").compatibility_status_with(
+            build_client_version("1.0.0")
+        ) == (CompatibilityStatus.INCOMPATIBLE)
 
     def test_unknown_when_other_none(self):
-        assert _v("0.1.113").compatibility_status_with(None) == (
+        assert build_client_version("0.1.113").compatibility_status_with(None) == (
             CompatibilityStatus.UNKNOWN
         )
 
     def test_patch_warning_text_only_for_patch_diff(self):
-        assert _v("0.1.113").get_patch_warning_text(_v("0.1.113")) is None
-        assert _v("0.1.113").get_patch_warning_text(_v("0.2.0")) is None
-        warning = _v("0.1.113").get_patch_warning_text(_v("0.1.114"))
+        assert (
+            build_client_version("0.1.113").get_patch_warning_text(
+                build_client_version("0.1.113")
+            )
+            is None
+        )
+        assert (
+            build_client_version("0.1.113").get_patch_warning_text(
+                build_client_version("0.2.0")
+            )
+            is None
+        )
+        warning = build_client_version("0.1.113").get_patch_warning_text(
+            build_client_version("0.1.114")
+        )
         assert warning is not None
         assert "0.1.113" in warning and "0.1.114" in warning
 
     def test_is_compatible_with_includes_patch_diff(self):
-        assert _v("0.1.113").is_compatible_with(_v("0.1.114")) is True
-        assert _v("0.1.113").is_compatible_with(_v("0.2.0")) is False
-        assert _v("0.1.113").is_compatible_with(None) is False
+        assert (
+            build_client_version("0.1.113").is_compatible_with(
+                build_client_version("0.1.114")
+            )
+            is True
+        )
+        assert (
+            build_client_version("0.1.113").is_compatible_with(
+                build_client_version("0.2.0")
+            )
+            is False
+        )
+        assert build_client_version("0.1.113").is_compatible_with(None) is False
 
 
 class TestPeerManager:
@@ -316,12 +339,12 @@ class TestPatchTolerance:
             int(current.syft_client_version.split(".")[1]),
             int(current.syft_client_version.split(".")[2]),
         )
-        patch_diff_version = _v(f"{major}.{minor}.{patch + 1}")
+        patch_diff_version = build_client_version(f"{major}.{minor}.{patch + 1}")
         _set_peer_version(do_manager, ds_manager.email, patch_diff_version)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            compatible = do_manager.peer_manager.get_compatible_peer_emails(
+            compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email in compatible
@@ -334,26 +357,32 @@ class TestPatchTolerance:
 
         current = VersionInfo.current()
         parts = current.syft_client_version.split(".")
-        patch_diff_version = _v(f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}")
+        patch_diff_version = build_client_version(
+            f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}"
+        )
         _set_peer_version(ds_manager, do_manager.email, patch_diff_version)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            ds_manager.peer_manager.check_version_for_submission(do_manager.email)
+            result = ds_manager.peer_manager.get_peer_compatibility_status(
+                do_manager.email, action=CompatAction.SUBMIT
+            )
+            result.raise_on_skip(operation="submit job")
+            result.maybe_warn()
         assert any("patch" in str(w.message).lower() for w in caught)
 
 
 class TestForceAllowIncompatiblePeers:
-    """Tests for force_allow_incompatible_peers and per-call allow_incompatible."""
+    """Tests for force_ignore_peer_version and per-call ignore_peer_version."""
 
     def test_incompatible_peer_skipped_by_default(self):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
+        _set_peer_version(do_manager, ds_manager.email, build_client_version("99.0.0"))
 
         do_manager.peer_manager.suppress_version_warnings = True
-        compatible = do_manager.peer_manager.get_compatible_peer_emails(
+        compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
             [ds_manager.email]
         )
         assert ds_manager.email not in compatible
@@ -362,51 +391,60 @@ class TestForceAllowIncompatiblePeers:
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
+        _set_peer_version(do_manager, ds_manager.email, build_client_version("99.0.0"))
 
-        do_manager.peer_manager.force_allow_incompatible_peers = True
+        do_manager.peer_manager.force_ignore_peer_version = True
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            compatible = do_manager.peer_manager.get_compatible_peer_emails(
+            compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email in compatible
         assert any("proceeding anyway" in str(w.message).lower() for w in caught)
 
-    def test_per_call_allow_incompatible_includes_peer(self):
+    def test_per_call_ignore_peer_version_includes_peer(self):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
+        _set_peer_version(do_manager, ds_manager.email, build_client_version("99.0.0"))
 
-        compatible = do_manager.peer_manager.get_compatible_peer_emails(
-            [ds_manager.email], allow_incompatible=True
+        compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
+            [ds_manager.email], ignore_peer_version=True
         )
         assert ds_manager.email in compatible
 
-    def test_per_call_allow_incompatible_in_submit(self):
+    def test_per_call_ignore_peer_version_in_submit(self):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-        _set_peer_version(ds_manager, do_manager.email, _v("99.0.0"))
+        _set_peer_version(ds_manager, do_manager.email, build_client_version("99.0.0"))
 
         with pytest.raises(VersionMismatchError):
-            ds_manager.peer_manager.check_version_for_submission(do_manager.email)
+            result = ds_manager.peer_manager.get_peer_compatibility_status(
+                do_manager.email, action=CompatAction.SUBMIT
+            )
+            result.raise_on_skip(operation="submit job")
 
         # With per-call override, should not raise
-        ds_manager.peer_manager.check_version_for_submission(
-            do_manager.email, allow_incompatible=True
+        result = ds_manager.peer_manager.get_peer_compatibility_status(
+            do_manager.email,
+            action=CompatAction.SUBMIT,
+            ignore_peer_version=True,
         )
+        result.raise_on_skip(operation="submit job")
 
     def test_force_allow_in_submit(self):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-        _set_peer_version(ds_manager, do_manager.email, _v("99.0.0"))
+        _set_peer_version(ds_manager, do_manager.email, build_client_version("99.0.0"))
 
-        ds_manager.peer_manager.force_allow_incompatible_peers = True
+        ds_manager.peer_manager.force_ignore_peer_version = True
         # Should not raise
-        ds_manager.peer_manager.check_version_for_submission(do_manager.email)
+        result = ds_manager.peer_manager.get_peer_compatibility_status(
+            do_manager.email, action=CompatAction.SUBMIT
+        )
+        result.raise_on_skip(operation="submit job")
 
 
 class TestVersionMismatchBehavior:
@@ -416,11 +454,13 @@ class TestVersionMismatchBehavior:
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-        _set_peer_version(do_manager, ds_manager.email, _v("0.0.1"))
+        _set_peer_version(do_manager, ds_manager.email, build_client_version("0.0.1"))
 
         do_manager.peer_manager.suppress_version_warnings = True
-        compatible_peers = do_manager.peer_manager.get_compatible_peer_emails(
-            [ds_manager.email], warn_incompatible=False
+        compatible_peers = (
+            do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
+                [ds_manager.email]
+            )
         )
         assert ds_manager.email not in compatible_peers
 
@@ -445,7 +485,7 @@ class TestVersionMismatchBehavior:
         job = do_manager.job_client.jobs[0]
         job.approve()
 
-        _set_peer_version(do_manager, ds_manager.email, _v("0.0.1"))
+        _set_peer_version(do_manager, ds_manager.email, build_client_version("0.0.1"))
 
         executed_jobs = []
 
@@ -473,6 +513,6 @@ class TestVersionMismatchBehavior:
         assert ds_manager.peer_manager.is_peer_version_compatible(do_manager.email)
         assert do_manager.peer_manager.is_peer_version_compatible(ds_manager.email)
 
-        _set_peer_version(do_manager, ds_manager.email, _v("99.0.0"))
+        _set_peer_version(do_manager, ds_manager.email, build_client_version("99.0.0"))
 
         assert not do_manager.peer_manager.is_peer_version_compatible(ds_manager.email)


### PR DESCRIPTION
## Summary
- `CompatibilityStatus` enum: `SAME` / `PATCH_DIFF` / `INCOMPATIBLE` / `UNKNOWN`. Only `syft_client_version` is compared — `protocol_version` differences no longer block.
- Patch-only mismatches warn but no longer skip peers in `sync`, `submit_bash_job` / `submit_python_job`, or `process_approved_jobs`.
- Replaced `ignore_protocol_version` / `ignore_client_version` on `PeerManager` with a single `force_allow_incompatible_peers`. Each peer-checking method on `SyftboxManager` also gets a per-call `allow_incompatible: bool = False`. Effective allow = `peer_manager.force_allow_incompatible_peers or allow_incompatible`.
- Test factories' `check_versions` flag is preserved (now maps to `force_allow_incompatible_peers=not check_versions`).

## Test plan
- [x] `just test-unit-fast` (338 passed)
- [x] `uv run pytest tests/unit/test_version_negotiation.py tests/unit/test_version_mismatch_flow.py` (32 passed)
- [x] `pre-commit run` clean

Override usage:
```python
manager.peer_manager.force_allow_incompatible_peers = True   # global
manager.sync(allow_incompatible=True)                        # per-call
manager.submit_python_job(user, code_path, allow_incompatible=True)
```