### PR TITLE
feat: lower notify poll interval default to 5s and honor configured value

### DIFF
--- a/packages/syft-bg/src/syft_bg/notify/config.py
+++ b/packages/syft-bg/src/syft_bg/notify/config.py
@@ -28,7 +28,7 @@ class NotifyConfig(BaseModel):
     sync_state_path: Path = Field(
         default_factory=lambda: get_default_paths().sync_state
     )
-    interval: int = 30
+    interval: int = 5
     monitor_jobs: bool = True
     monitor_peers: bool = True
     heartbeat_enabled: bool = True

--- a/packages/syft-bg/src/syft_bg/notify/orchestrator.py
+++ b/packages/syft-bg/src/syft_bg/notify/orchestrator.py
@@ -26,6 +26,7 @@ class NotificationOrchestrator(BaseOrchestrator):
     ):
         super().__init__()
         self.config = config
+        self.interval = config.interval
         self._job_monitor = job_monitor
         self._peer_monitor: Optional[PeerMonitor] = peer_monitor
         self._heartbeat: Optional[Heartbeat] = heartbeat


### PR DESCRIPTION
## Summary
- Drop `NotifyConfig.interval` default from `30` to `5` seconds.
- Fix `NotificationOrchestrator.__init__` to set `self.interval = config.interval` (matching `ApprovalOrchestrator`); previously the configured value was silently ignored because the orchestrator inherited `BaseOrchestrator`'s hardcoded `self.interval = 30`.

After this, callers can override at startup with:

```python
syft_bg.init(..., settings={"notify": {"interval": 5}})
```

## Test plan
- [x] Smoke: `NotifyConfig().interval == 5`; `NotifyConfig(interval=42).interval == 42`
- [x] Smoke: `NotificationOrchestrator(config=NotifyConfig(interval=30), job_monitor=Mock()).interval == 30`
- [x] `pre-commit run --files <changed>` green