### PR TITLE
feat: accept full redirect URL in browserless credentials_to_token

### DIFF
--- a/syft_client/gdrive_utils.py
+++ b/syft_client/gdrive_utils.py
@@ -42,6 +42,18 @@ DO_SCOPES = [
 ]
 
 
+def _extract_auth_code(response: str) -> str:
+    """Extract the OAuth authorization code from a raw code or full redirect URL."""
+    if response.startswith(("http://", "https://")):
+        query_code = parse_qs(urlparse(response).query).get("code")
+        if not query_code:
+            raise ValueError(
+                f"Could not find 'code' query parameter in URL: {response}"
+            )
+        return query_code[0]
+    return response
+
+
 def credentials_to_token(
     credentials_path: str | Path,
     output_path: str | Path | None = None,
@@ -76,7 +88,10 @@ def credentials_to_token(
         print("Visit this URL to authorize Google Drive access:\n")
         print(f"  {auth_url}\n")
         print("After authorizing, you'll see a page that won't load.")
-        code = input("Paste the authorization code here: ").strip()
+        response = input(
+            "Paste the authorization code OR the full redirect URL here: "
+        ).strip()
+        code = _extract_auth_code(response)
         flow.fetch_token(code=code)
         creds = flow.credentials
         return creds

--- a/tests/unit/test_extract_auth_code.py
+++ b/tests/unit/test_extract_auth_code.py
@@ -1,0 +1,29 @@
+import pytest
+
+from syft_client.gdrive_utils import _extract_auth_code
+
+
+def test_raw_code_returned_as_is():
+    code = "4/0AFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEAA"
+    assert _extract_auth_code(code) == code
+
+
+def test_full_redirect_url_extracts_code():
+    fake_code = "4/0AFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEcodeFAKEAA"
+    url = (
+        "http://localhost:1/?state=FAKEstateFAKEstateFAKEstateFA"
+        "&iss=https://accounts.google.com"
+        f"&code={fake_code}"
+        "&scope=https://www.googleapis.com/auth/drive"
+    )
+    assert _extract_auth_code(url) == fake_code
+
+
+def test_https_url_extracts_code():
+    url = "https://example.com/callback?code=abc123&state=xyz"
+    assert _extract_auth_code(url) == "abc123"
+
+
+def test_url_without_code_raises():
+    with pytest.raises(ValueError, match="Could not find 'code'"):
+        _extract_auth_code("http://localhost:1/?state=xyz")


### PR DESCRIPTION
## Summary
- `credentials_to_token` browserless prompt now accepts either the raw OAuth `code` or the full `http://localhost:1/?...&code=...&scope=...` redirect URL pasted from the browser.
- Added `_extract_auth_code()` helper that parses the `code` query parameter when given a URL and returns the input as-is otherwise.
- Added unit tests covering raw codes, full redirect URLs, https URLs, and missing-`code` errors.

## Test plan
- [x] `uv run pytest tests/unit/test_extract_auth_code.py` — 4 passed
- [x] `pre-commit run` on changed files — all passed
- [ ] Manually verify pasting the full redirect URL produces a valid `token.json`