### PR TITLE
fix: retry on stale-socket transport errors in Google Drive calls

### DIFF
--- a/scripts/reproduce_stale_socket.py
+++ b/scripts/reproduce_stale_socket.py
@@ -1,0 +1,151 @@
+"""
+Reproduce the stale-socket failure mode that surfaces as
+ConnectionResetError / BrokenPipeError during ds_client.sync() and
+ds_client.submit_python_job().
+
+Strategy: warm the httplib2 keepalive with one Drive call, then close the
+underlying TCP socket from outside (simulating Google's idle-close), then
+make a second Drive call. The second call hits the dead cached socket and
+fails the same way it does in the notebook -- but deterministically and
+in <1s, no waiting for Google to time us out.
+
+Reads credentials from notebooks/beach/internal/.env (TOKEN_DO_WITH_SCOPES +
+DO_EMAIL by default; pass --side ds to use TOKEN_DS + DS_EMAIL).
+
+Usage:
+    # Show the raw failure (the error you saw in the notebook):
+    uv run python scripts/reproduce_stale_socket.py --mode raw
+
+    # Show that execute_with_retries handles it (passes only after Fix A):
+    uv run python scripts/reproduce_stale_socket.py --mode retry
+
+    # Use a non-default .env or the DS-side token:
+    uv run python scripts/reproduce_stale_socket.py --env path/to/.env --side ds
+"""
+
+import argparse
+import os
+import socket
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google.oauth2.credentials import Credentials
+
+from syft_client.sync.connections.drive.gdrive_retry import execute_with_retries
+from syft_client.sync.connections.drive.gdrive_transport import build_drive_service
+
+SCOPES = ["https://www.googleapis.com/auth/drive"]
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ENV = REPO_ROOT / "notebooks" / "beach" / "internal" / ".env"
+
+SIDE_TO_KEYS = {
+    "do": ("TOKEN_DO_WITH_SCOPES", "DO_EMAIL"),
+    "ds": ("TOKEN_DS", "DS_EMAIL"),
+}
+
+
+def load_env(env_path: Path) -> None:
+    if not env_path.exists():
+        raise SystemExit(f"No .env at {env_path}. Pass --env explicitly.")
+    load_dotenv(env_path, override=False)
+
+
+def build_service(side: str):
+    token_key, email_key = SIDE_TO_KEYS[side]
+    token_path = os.environ.get(token_key)
+    email = os.environ.get(email_key)
+    if not token_path or not email:
+        raise SystemExit(
+            f"{token_key} and/or {email_key} not set after loading .env."
+        )
+    if not Path(token_path).exists():
+        raise SystemExit(f"Token file not found: {token_path}")
+    creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+    print(f"[ ] Using {side.upper()} side: {email}")
+    return build_drive_service(creds)
+
+
+def kill_cached_sockets(service) -> int:
+    """Tear down every cached httplib2 connection at the TCP layer.
+
+    Uses shutdown(SHUT_RDWR) rather than close(): this matches what happens
+    when Google's frontend FIN-closes our idle keepalive. Our local fd stays
+    valid, so the next send/recv gets EPIPE / ECONNRESET from the kernel --
+    which is the exact failure mode that surfaces in the notebook.
+
+    close() would invalidate the fd locally and produce EBADF instead, which
+    is *not* the bug we're trying to reproduce.
+    """
+    http = service._http.http  # AuthorizedHttp.http -> httplib2.Http
+    killed = 0
+    for conn in list(http.connections.values()):
+        sock = getattr(conn, "sock", None)
+        if sock is None:
+            continue
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            # Already half-closed or not connected; nothing useful to do.
+            continue
+        killed += 1
+    return killed
+
+
+def make_request(service):
+    return service.files().list(
+        q="name='SyftBox' and trashed=false",
+        fields="files(id, name)",
+        pageSize=1,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("raw", "retry"),
+        default="raw",
+        help="raw: call .execute() directly. retry: route through execute_with_retries.",
+    )
+    parser.add_argument(
+        "--side",
+        choices=tuple(SIDE_TO_KEYS),
+        default="do",
+        help="Which token/email pair from .env to use.",
+    )
+    parser.add_argument(
+        "--env",
+        type=Path,
+        default=DEFAULT_ENV,
+        help=f"Path to .env file (default: {DEFAULT_ENV}).",
+    )
+    args = parser.parse_args()
+
+    load_env(args.env)
+    service = build_service(args.side)
+
+    print("[1/3] Warming keepalive with one Drive call...")
+    make_request(service).execute()
+    print("      ok.")
+
+    killed = kill_cached_sockets(service)
+    print(f"[2/3] Closed {killed} cached socket(s) -- next call will hit a dead socket.")
+
+    print(f"[3/3] Second call (mode={args.mode})...")
+    try:
+        if args.mode == "raw":
+            make_request(service).execute()
+        else:
+            execute_with_retries(make_request(service))
+    except (ConnectionResetError, BrokenPipeError) as e:
+        print(f"      REPRODUCED: {type(e).__name__}: {e}")
+        raise SystemExit(1)
+    except Exception as e:
+        print(f"      Unexpected {type(e).__name__}: {e}")
+        raise
+
+    print("      ok -- call succeeded (fix is working, or socket happened to recover).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reproduce_stale_socket.py
+++ b/scripts/reproduce_stale_socket.py
@@ -55,9 +55,7 @@ def build_service(side: str):
     token_path = os.environ.get(token_key)
     email = os.environ.get(email_key)
     if not token_path or not email:
-        raise SystemExit(
-            f"{token_key} and/or {email_key} not set after loading .env."
-        )
+        raise SystemExit(f"{token_key} and/or {email_key} not set after loading .env.")
     if not Path(token_path).exists():
         raise SystemExit(f"Token file not found: {token_path}")
     creds = Credentials.from_authorized_user_file(token_path, SCOPES)
@@ -129,7 +127,9 @@ def main():
     print("      ok.")
 
     killed = kill_cached_sockets(service)
-    print(f"[2/3] Closed {killed} cached socket(s) -- next call will hit a dead socket.")
+    print(
+        f"[2/3] Closed {killed} cached socket(s) -- next call will hit a dead socket."
+    )
 
     print(f"[3/3] Second call (mode={args.mode})...")
     try:

--- a/syft_client/sync/connections/drive/gdrive_retry.py
+++ b/syft_client/sync/connections/drive/gdrive_retry.py
@@ -1,7 +1,10 @@
 """Retry logic for Google Drive API calls."""
 
+import http.client
 import logging
 import random
+import socket
+import ssl
 import time
 from typing import Any, TypeVar
 
@@ -24,11 +27,27 @@ RETRYABLE_REASONS = {
     "badRequest",  # GDrive resumable uploads can return transient 400 "badRequest"
 }
 
+# Socket/TLS transients raised by httplib2 when Google closes an idle keepalive
+# connection. googleapiclient's own retry loop only catches ssl.SSLError and
+# socket.timeout, so these escape and surface to callers as unhandled errors.
+RETRYABLE_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    ConnectionResetError,
+    ConnectionAbortedError,
+    BrokenPipeError,
+    TimeoutError,
+    socket.timeout,
+    ssl.SSLError,
+    http.client.RemoteDisconnected,
+    http.client.BadStatusLine,
+)
+
 T = TypeVar("T")
 
 
 def is_retryable_error(error: Exception) -> bool:
     """Check if an error is transient and should be retried."""
+    if isinstance(error, RETRYABLE_TRANSPORT_ERRORS):
+        return True
     if isinstance(error, HttpError):
         if error.resp.status in RETRYABLE_STATUS_CODES:
             return True
@@ -38,6 +57,12 @@ def is_retryable_error(error: Exception) -> bool:
                 if detail.get("reason") in RETRYABLE_REASONS:
                     return True
     return False
+
+
+def _describe(error: Exception) -> str:
+    if isinstance(error, HttpError):
+        return str(error.resp.status)
+    return type(error).__name__
 
 
 def execute_with_retries(
@@ -70,7 +95,7 @@ def execute_with_retries(
     for attempt in range(max_retries + 1):
         try:
             return request.execute()
-        except HttpError as e:
+        except (HttpError, *RETRYABLE_TRANSPORT_ERRORS) as e:
             last_error = e
             if not is_retryable_error(e) or attempt == max_retries:
                 raise
@@ -81,7 +106,7 @@ def execute_with_retries(
 
             logger.warning(
                 f"Google Drive API error (attempt {attempt + 1}/{max_retries + 1}): "
-                f"{e.resp.status} - retrying in {sleep_time:.2f}s"
+                f"{_describe(e)} - retrying in {sleep_time:.2f}s"
             )
             time.sleep(sleep_time)
             delay = min(delay * backoff_multiplier, max_delay)
@@ -117,7 +142,7 @@ def next_chunk_with_retries(
     for attempt in range(max_retries + 1):
         try:
             return downloader.next_chunk()
-        except HttpError as e:
+        except (HttpError, *RETRYABLE_TRANSPORT_ERRORS) as e:
             last_error = e
             if not is_retryable_error(e) or attempt == max_retries:
                 raise
@@ -128,7 +153,7 @@ def next_chunk_with_retries(
 
             logger.warning(
                 f"Google Drive download error (attempt {attempt + 1}/{max_retries + 1}): "
-                f"{e.resp.status} - retrying in {sleep_time:.2f}s"
+                f"{_describe(e)} - retrying in {sleep_time:.2f}s"
             )
             time.sleep(sleep_time)
             delay = min(delay * backoff_multiplier, max_delay)
@@ -162,7 +187,7 @@ def batch_execute_with_retries(
         try:
             batch.execute()
             return
-        except HttpError as e:
+        except (HttpError, *RETRYABLE_TRANSPORT_ERRORS) as e:
             last_error = e
             if not is_retryable_error(e) or attempt == max_retries:
                 raise
@@ -173,7 +198,7 @@ def batch_execute_with_retries(
 
             logger.warning(
                 f"Google Drive batch error (attempt {attempt + 1}/{max_retries + 1}): "
-                f"{e.resp.status} - retrying in {sleep_time:.2f}s"
+                f"{_describe(e)} - retrying in {sleep_time:.2f}s"
             )
             time.sleep(sleep_time)
             delay = min(delay * backoff_multiplier, max_delay)

--- a/tests/unit/test_gdrive_retry.py
+++ b/tests/unit/test_gdrive_retry.py
@@ -1,0 +1,210 @@
+"""Unit tests for syft_client.sync.connections.drive.gdrive_retry.
+
+Focus: the retry helpers must recover from socket-level transients
+(ConnectionResetError, BrokenPipeError, etc.) that surface when httplib2's
+cached keepalive connection is closed server-side. Pre-fix these escaped the
+retry loop entirely; this test pins the behavior so it doesn't regress.
+"""
+
+import http.client
+import socket
+import ssl
+from unittest.mock import Mock, patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from syft_client.sync.connections.drive.gdrive_retry import (
+    RETRYABLE_TRANSPORT_ERRORS,
+    batch_execute_with_retries,
+    execute_with_retries,
+    is_retryable_error,
+    next_chunk_with_retries,
+)
+
+
+def _http_error(status: int) -> HttpError:
+    resp = Mock()
+    resp.status = status
+    resp.reason = "test"
+    return HttpError(resp, b"{}")
+
+
+TRANSPORT_INSTANCES = [
+    ConnectionResetError("peer reset"),
+    ConnectionAbortedError("aborted"),
+    BrokenPipeError("epipe"),
+    TimeoutError("timed out"),
+    socket.timeout("sock timeout"),
+    ssl.SSLError("ssl"),
+    http.client.RemoteDisconnected("remote disconnected"),
+    http.client.BadStatusLine("bad status"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """Patch time.sleep so tests run instantly."""
+    with patch("syft_client.sync.connections.drive.gdrive_retry.time.sleep"):
+        yield
+
+
+# ---------- is_retryable_error ----------------------------------------------
+
+
+@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
+def test_is_retryable_error_transport(err):
+    assert is_retryable_error(err) is True
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 429])
+def test_is_retryable_error_retryable_http(status):
+    assert is_retryable_error(_http_error(status)) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409])
+def test_is_retryable_error_non_retryable_http(status):
+    assert is_retryable_error(_http_error(status)) is False
+
+
+def test_is_retryable_error_unrelated_exception():
+    assert is_retryable_error(ValueError("nope")) is False
+
+
+# ---------- execute_with_retries --------------------------------------------
+
+
+@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
+def test_execute_with_retries_recovers_from_transport_error(err):
+    """After Fix A, transport errors are caught and retried."""
+    request = Mock()
+    request.execute.side_effect = [err, {"ok": True}]
+
+    result = execute_with_retries(request, initial_delay=0, max_delay=0)
+
+    assert result == {"ok": True}
+    assert request.execute.call_count == 2
+
+
+def test_execute_with_retries_exhausts_then_raises():
+    request = Mock()
+    request.execute.side_effect = ConnectionResetError("peer reset")
+
+    with pytest.raises(ConnectionResetError):
+        execute_with_retries(request, max_retries=2, initial_delay=0, max_delay=0)
+
+    # max_retries=2 means 1 initial attempt + 2 retries = 3 total.
+    assert request.execute.call_count == 3
+
+
+def test_execute_with_retries_non_retryable_http_raises_immediately():
+    request = Mock()
+    request.execute.side_effect = _http_error(404)
+
+    with pytest.raises(HttpError):
+        execute_with_retries(request, initial_delay=0, max_delay=0)
+
+    assert request.execute.call_count == 1
+
+
+def test_execute_with_retries_retries_retryable_http():
+    request = Mock()
+    request.execute.side_effect = [_http_error(503), _http_error(500), {"ok": True}]
+
+    result = execute_with_retries(request, initial_delay=0, max_delay=0)
+
+    assert result == {"ok": True}
+    assert request.execute.call_count == 3
+
+
+def test_execute_with_retries_mixed_error_types():
+    """Sequence mixing transport and HTTP transients both retry."""
+    request = Mock()
+    request.execute.side_effect = [
+        ConnectionResetError("reset"),
+        _http_error(503),
+        BrokenPipeError("epipe"),
+        {"ok": True},
+    ]
+
+    result = execute_with_retries(
+        request, max_retries=5, initial_delay=0, max_delay=0
+    )
+
+    assert result == {"ok": True}
+    assert request.execute.call_count == 4
+
+
+def test_execute_with_retries_passes_through_unrelated_exception():
+    """Non-transport, non-HttpError exceptions are not caught by the retry."""
+    request = Mock()
+    request.execute.side_effect = ValueError("nope")
+
+    with pytest.raises(ValueError):
+        execute_with_retries(request, initial_delay=0, max_delay=0)
+
+    assert request.execute.call_count == 1
+
+
+# ---------- next_chunk_with_retries -----------------------------------------
+
+
+@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
+def test_next_chunk_with_retries_recovers_from_transport_error(err):
+    downloader = Mock()
+    downloader.next_chunk.side_effect = [err, (Mock(), True)]
+
+    status, done = next_chunk_with_retries(
+        downloader, initial_delay=0, max_delay=0
+    )
+
+    assert done is True
+    assert downloader.next_chunk.call_count == 2
+
+
+def test_next_chunk_with_retries_exhausts_then_raises():
+    downloader = Mock()
+    downloader.next_chunk.side_effect = BrokenPipeError("epipe")
+
+    with pytest.raises(BrokenPipeError):
+        next_chunk_with_retries(
+            downloader, max_retries=1, initial_delay=0, max_delay=0
+        )
+
+    assert downloader.next_chunk.call_count == 2
+
+
+# ---------- batch_execute_with_retries --------------------------------------
+
+
+@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
+def test_batch_execute_with_retries_recovers_from_transport_error(err):
+    batch = Mock()
+    batch.execute.side_effect = [err, None]
+
+    batch_execute_with_retries(batch, initial_delay=0, max_delay=0)
+
+    assert batch.execute.call_count == 2
+
+
+def test_batch_execute_with_retries_exhausts_then_raises():
+    batch = Mock()
+    batch.execute.side_effect = ConnectionResetError("reset")
+
+    with pytest.raises(ConnectionResetError):
+        batch_execute_with_retries(
+            batch, max_retries=0, initial_delay=0, max_delay=0
+        )
+
+    assert batch.execute.call_count == 1
+
+
+# ---------- module-level invariants -----------------------------------------
+
+
+def test_all_listed_transport_errors_are_recognized_as_retryable():
+    """RETRYABLE_TRANSPORT_ERRORS and is_retryable_error must agree."""
+    for cls in RETRYABLE_TRANSPORT_ERRORS:
+        # ssl.SSLError requires an arg; others accept a string. Both work.
+        instance = cls("x") if cls is not http.client.BadStatusLine else cls("x")
+        assert is_retryable_error(instance) is True, cls

--- a/tests/unit/test_gdrive_retry.py
+++ b/tests/unit/test_gdrive_retry.py
@@ -4,6 +4,12 @@ Focus: the retry helpers must recover from socket-level transients
 (ConnectionResetError, BrokenPipeError, etc.) that surface when httplib2's
 cached keepalive connection is closed server-side. Pre-fix these escaped the
 retry loop entirely; this test pins the behavior so it doesn't regress.
+
+The three retry helpers (execute / next_chunk / batch) share the same
+`except (HttpError, *RETRYABLE_TRANSPORT_ERRORS)` clause, so the
+parametrized registry test in `is_retryable_error` is what actually proves
+each error type is recognized. The per-helper tests are smoke tests to
+confirm the wiring, not exhaustive cross-products.
 """
 
 import http.client
@@ -15,7 +21,6 @@ import pytest
 from googleapiclient.errors import HttpError
 
 from syft_client.sync.connections.drive.gdrive_retry import (
-    RETRYABLE_TRANSPORT_ERRORS,
     batch_execute_with_retries,
     execute_with_retries,
     is_retryable_error,
@@ -49,7 +54,10 @@ def _no_sleep():
         yield
 
 
-# ---------- is_retryable_error ----------------------------------------------
+# ---------- is_retryable_error registry -------------------------------------
+# These are the safety net: they prove every error class we claim to handle
+# is actually in the retryable set. If someone removes a class from
+# RETRYABLE_TRANSPORT_ERRORS, the matching case here fails by name.
 
 
 @pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
@@ -57,14 +65,14 @@ def test_is_retryable_error_transport(err):
     assert is_retryable_error(err) is True
 
 
-@pytest.mark.parametrize("status", [500, 502, 503, 429])
-def test_is_retryable_error_retryable_http(status):
-    assert is_retryable_error(_http_error(status)) is True
+def test_is_retryable_error_retryable_http_statuses():
+    for status in (500, 502, 503, 429):
+        assert is_retryable_error(_http_error(status)) is True, status
 
 
-@pytest.mark.parametrize("status", [400, 401, 403, 404, 409])
-def test_is_retryable_error_non_retryable_http(status):
-    assert is_retryable_error(_http_error(status)) is False
+def test_is_retryable_error_non_retryable_http_statuses():
+    for status in (400, 403, 404):
+        assert is_retryable_error(_http_error(status)) is False, status
 
 
 def test_is_retryable_error_unrelated_exception():
@@ -72,13 +80,14 @@ def test_is_retryable_error_unrelated_exception():
 
 
 # ---------- execute_with_retries --------------------------------------------
+# This is the hot path -- most Drive calls flow through here. The exhaust /
+# immediate-raise / pass-through behaviors are covered here once; the other
+# two helpers use the same loop structure and only get smoke tests.
 
 
-@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
-def test_execute_with_retries_recovers_from_transport_error(err):
-    """After Fix A, transport errors are caught and retried."""
+def test_execute_with_retries_recovers_from_transport_error():
     request = Mock()
-    request.execute.side_effect = [err, {"ok": True}]
+    request.execute.side_effect = [ConnectionResetError("reset"), {"ok": True}]
 
     result = execute_with_retries(request, initial_delay=0, max_delay=0)
 
@@ -109,32 +118,15 @@ def test_execute_with_retries_non_retryable_http_raises_immediately():
 
 def test_execute_with_retries_retries_retryable_http():
     request = Mock()
-    request.execute.side_effect = [_http_error(503), _http_error(500), {"ok": True}]
+    request.execute.side_effect = [_http_error(503), {"ok": True}]
 
     result = execute_with_retries(request, initial_delay=0, max_delay=0)
 
     assert result == {"ok": True}
-    assert request.execute.call_count == 3
-
-
-def test_execute_with_retries_mixed_error_types():
-    """Sequence mixing transport and HTTP transients both retry."""
-    request = Mock()
-    request.execute.side_effect = [
-        ConnectionResetError("reset"),
-        _http_error(503),
-        BrokenPipeError("epipe"),
-        {"ok": True},
-    ]
-
-    result = execute_with_retries(request, max_retries=5, initial_delay=0, max_delay=0)
-
-    assert result == {"ok": True}
-    assert request.execute.call_count == 4
+    assert request.execute.call_count == 2
 
 
 def test_execute_with_retries_passes_through_unrelated_exception():
-    """Non-transport, non-HttpError exceptions are not caught by the retry."""
     request = Mock()
     request.execute.side_effect = ValueError("nope")
 
@@ -144,59 +136,26 @@ def test_execute_with_retries_passes_through_unrelated_exception():
     assert request.execute.call_count == 1
 
 
-# ---------- next_chunk_with_retries -----------------------------------------
+# ---------- next_chunk_with_retries / batch_execute_with_retries ------------
+# Smoke tests. Same retry loop as execute_with_retries; we only need to
+# confirm the helper actually wires the right method (next_chunk / execute)
+# to the loop.
 
 
-@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
-def test_next_chunk_with_retries_recovers_from_transport_error(err):
+def test_next_chunk_with_retries_recovers():
     downloader = Mock()
-    downloader.next_chunk.side_effect = [err, (Mock(), True)]
+    downloader.next_chunk.side_effect = [BrokenPipeError("epipe"), (Mock(), True)]
 
-    status, done = next_chunk_with_retries(downloader, initial_delay=0, max_delay=0)
+    _, done = next_chunk_with_retries(downloader, initial_delay=0, max_delay=0)
 
     assert done is True
     assert downloader.next_chunk.call_count == 2
 
 
-def test_next_chunk_with_retries_exhausts_then_raises():
-    downloader = Mock()
-    downloader.next_chunk.side_effect = BrokenPipeError("epipe")
-
-    with pytest.raises(BrokenPipeError):
-        next_chunk_with_retries(downloader, max_retries=1, initial_delay=0, max_delay=0)
-
-    assert downloader.next_chunk.call_count == 2
-
-
-# ---------- batch_execute_with_retries --------------------------------------
-
-
-@pytest.mark.parametrize("err", TRANSPORT_INSTANCES)
-def test_batch_execute_with_retries_recovers_from_transport_error(err):
+def test_batch_execute_with_retries_recovers():
     batch = Mock()
-    batch.execute.side_effect = [err, None]
+    batch.execute.side_effect = [ConnectionResetError("reset"), None]
 
     batch_execute_with_retries(batch, initial_delay=0, max_delay=0)
 
     assert batch.execute.call_count == 2
-
-
-def test_batch_execute_with_retries_exhausts_then_raises():
-    batch = Mock()
-    batch.execute.side_effect = ConnectionResetError("reset")
-
-    with pytest.raises(ConnectionResetError):
-        batch_execute_with_retries(batch, max_retries=0, initial_delay=0, max_delay=0)
-
-    assert batch.execute.call_count == 1
-
-
-# ---------- module-level invariants -----------------------------------------
-
-
-def test_all_listed_transport_errors_are_recognized_as_retryable():
-    """RETRYABLE_TRANSPORT_ERRORS and is_retryable_error must agree."""
-    for cls in RETRYABLE_TRANSPORT_ERRORS:
-        # ssl.SSLError requires an arg; others accept a string. Both work.
-        instance = cls("x") if cls is not http.client.BadStatusLine else cls("x")
-        assert is_retryable_error(instance) is True, cls

--- a/tests/unit/test_gdrive_retry.py
+++ b/tests/unit/test_gdrive_retry.py
@@ -127,9 +127,7 @@ def test_execute_with_retries_mixed_error_types():
         {"ok": True},
     ]
 
-    result = execute_with_retries(
-        request, max_retries=5, initial_delay=0, max_delay=0
-    )
+    result = execute_with_retries(request, max_retries=5, initial_delay=0, max_delay=0)
 
     assert result == {"ok": True}
     assert request.execute.call_count == 4
@@ -154,9 +152,7 @@ def test_next_chunk_with_retries_recovers_from_transport_error(err):
     downloader = Mock()
     downloader.next_chunk.side_effect = [err, (Mock(), True)]
 
-    status, done = next_chunk_with_retries(
-        downloader, initial_delay=0, max_delay=0
-    )
+    status, done = next_chunk_with_retries(downloader, initial_delay=0, max_delay=0)
 
     assert done is True
     assert downloader.next_chunk.call_count == 2
@@ -167,9 +163,7 @@ def test_next_chunk_with_retries_exhausts_then_raises():
     downloader.next_chunk.side_effect = BrokenPipeError("epipe")
 
     with pytest.raises(BrokenPipeError):
-        next_chunk_with_retries(
-            downloader, max_retries=1, initial_delay=0, max_delay=0
-        )
+        next_chunk_with_retries(downloader, max_retries=1, initial_delay=0, max_delay=0)
 
     assert downloader.next_chunk.call_count == 2
 
@@ -192,9 +186,7 @@ def test_batch_execute_with_retries_exhausts_then_raises():
     batch.execute.side_effect = ConnectionResetError("reset")
 
     with pytest.raises(ConnectionResetError):
-        batch_execute_with_retries(
-            batch, max_retries=0, initial_delay=0, max_delay=0
-        )
+        batch_execute_with_retries(batch, max_retries=0, initial_delay=0, max_delay=0)
 
     assert batch.execute.call_count == 1
 


### PR DESCRIPTION
## Summary
- Broaden `execute_with_retries`, `next_chunk_with_retries`, and `batch_execute_with_retries` to also catch socket/TLS transients (`ConnectionResetError`, `BrokenPipeError`, `TimeoutError`, `socket.timeout`, `ssl.SSLError`, `ConnectionAbortedError`, `http.client.RemoteDisconnected`, `http.client.BadStatusLine`). These were escaping the retry loop and surfacing to notebooks as unhandled exceptions during `ds_client.sync()` and `submit_python_job()`.
- Add 18 unit tests in `tests/unit/test_gdrive_retry.py` — the parametrized registry test pins every transport error class to `is_retryable_error`; the per-helper tests cover recovery, exhaustion, non-retryable HTTP fast-path, retryable HTTP retry, and pass-through of unrelated exceptions.
- Add `scripts/reproduce_stale_socket.py` — deterministic reproducer using `shutdown(SHUT_RDWR)` on the cached socket so the fix can be validated end-to-end in <1s, without waiting for Google's idle-close timer.

## Why
`httplib2` reuses a cached HTTP/1.1 keepalive connection across Drive calls. Google's frontends silently FIN-close idle sockets after a few seconds; the next call grabs the dead socket from the cache and the OS returns `ECONNRESET` / `EPIPE`. The existing retry helper only caught `HttpError` (built from an HTTP response), so these errors — which fire *before* any HTTP response exists — bypassed retry entirely and propagated up.

The retry mechanism that already exists (exponential backoff with jitter, default 3 retries from 1s to 8s) is the right shape for this; the only fix needed was teaching it which exception types to catch. `httplib2`'s `HTTPException` recovery path handles the actual socket replacement on the next attempt.

## Test plan
- [x] `pytest tests/unit/test_gdrive_retry.py` — 18/18 pass
- [x] `pytest tests/unit/test_gdrive_pagination.py` — 11/11 pass (no regression)
- [x] `python scripts/reproduce_stale_socket.py --mode raw` — reproduces `BrokenPipeError`
- [x] `python scripts/reproduce_stale_socket.py --mode retry` — succeeds after one retry (logs `BrokenPipeError - retrying in 1.20s` then `ok`)

## Out of scope / follow-up
- 17 raw `.execute()` call sites in cleanup paths (`delete_syftbox` and helpers in `gdrive_transport.py:1810–2233`) still bypass the retry. They'd be vulnerable to the same transient if hit, but cleanup operations are typically recoverable on next run. Worth a follow-up if we want full coverage.
- Refining the retry *policy* (split transport-error and HTTP-error paths; for stale sockets, purge cache and retry once without backoff instead of the full 1s/2s/4s schedule) was discussed but deferred for team review. The current change is the conservative "make the existing retry catch the right exceptions" change; the policy refinement can land on top.