### PR TITLE
fix: expand ~ in credentials_to_token paths

### DIFF
--- a/syft_client/gdrive_utils.py
+++ b/syft_client/gdrive_utils.py
@@ -71,11 +71,11 @@ def credentials_to_token(
     Returns:
         Path to the written token file.
     """
-    credentials_path = Path(credentials_path)
+    credentials_path = Path(credentials_path).expanduser()
     if output_path is None:
         output_path = credentials_path.parent / "token.json"
     else:
-        output_path = Path(output_path)
+        output_path = Path(output_path).expanduser()
 
     scopes = DO_SCOPES if do_scopes else GDRIVE_SCOPES
     flow = InstalledAppFlow.from_client_secrets_file(


### PR DESCRIPTION
## Summary
- `credentials_to_token()` now calls `.expanduser()` on both `credentials_path` and `output_path`, so paths like `~/Desktop/creds.json` resolve correctly instead of being treated as a literal `~` directory.

## Test plan
- [ ] Verify `credentials_to_token("~/Desktop/creds.json")` resolves to the home directory
- [ ] Verify absolute paths still work as before