### PR TITLE
feat: configurable skip_on_patch_version_difference per role

### DIFF
--- a/syft_client/sync/version/peer_manager.py
+++ b/syft_client/sync/version/peer_manager.py
@@ -9,7 +9,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, PrivateAttr
+from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 
 from syft_client.sync.connections.base_connection import ConnectionConfig
 from syft_client.sync.connections.connection_router import ConnectionRouter
@@ -96,6 +96,15 @@ class PeerManagerConfig(BaseModel):
     has_do_role: bool = False
     has_ds_role: bool = False
     use_encryption: bool = False
+    # None means "default by role" — resolved in the model_validator below
+    # to True for DOs (has_do_role) and False for DS-only managers.
+    skip_on_patch_version_difference: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _default_skip_on_patch(self) -> "PeerManagerConfig":
+        if self.skip_on_patch_version_difference is None:
+            self.skip_on_patch_version_difference = self.has_do_role
+        return self
 
 
 class PeerManager(BaseModel):
@@ -112,6 +121,7 @@ class PeerManager(BaseModel):
     n_threads: int = 10
     has_do_role: bool = False
     has_ds_role: bool = False
+    skip_on_patch_version_difference: bool = False
 
     _own_version: Optional[VersionInfo] = PrivateAttr(default=None)
     _executor: Optional[ThreadPoolExecutor] = PrivateAttr(default=None)
@@ -160,6 +170,9 @@ class PeerManager(BaseModel):
             n_threads=config.n_threads,
             has_do_role=config.has_do_role,
             has_ds_role=config.has_ds_role,
+            skip_on_patch_version_difference=bool(
+                config.skip_on_patch_version_difference
+            ),
         )
 
     def model_post_init(self, __context) -> None:
@@ -288,6 +301,22 @@ class PeerManager(BaseModel):
                 if peer_version is not None
                 else None
             )
+            if self.skip_on_patch_version_difference:
+                effective_ignore = self.force_ignore_peer_version or ignore_peer_version
+                if effective_ignore:
+                    return PeerCompatibilityResult(
+                        should_skip=False,
+                        explanation_not_skip=(
+                            f"Proceeding anyway to {action.value} for peer "
+                            f"{peer_email}: {patch_text}."
+                        ),
+                        **common,
+                    )
+                return PeerCompatibilityResult(
+                    should_skip=True,
+                    explanation_skip=f"Skipping peer {peer_email}: {patch_text}.",
+                    **common,
+                )
             explanation_not_skip = (
                 f"Peer {peer_email}: {patch_text}" if patch_text else None
             )

--- a/tests/unit/test_version_negotiation.py
+++ b/tests/unit/test_version_negotiation.py
@@ -325,42 +325,51 @@ def _set_peer_version(manager: SyftboxManager, peer_email: str, version: Version
     peer.version = version
 
 
-class TestPatchTolerance:
-    """Tests that patch-only differences warn but don't block."""
+def _patch_plus_one_version() -> VersionInfo:
+    """Return a VersionInfo that bumps the current patch level by one."""
+    parts = VersionInfo.current().syft_client_version.split(".")
+    return build_client_version(f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}")
 
-    def test_patch_diff_does_not_skip_in_sync(self):
+
+class TestPatchTolerance:
+    """Patch-only differences: DSes warn but don't skip; DOs skip by default."""
+
+    def test_patch_diff_does_not_skip_in_sync_for_ds(self):
+        """DS-side default: patch differences warn but do not skip."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
+        _set_peer_version(ds_manager, do_manager.email, _patch_plus_one_version())
 
-        current = VersionInfo.current()
-        major, minor, patch = (
-            int(current.syft_client_version.split(".")[0]),
-            int(current.syft_client_version.split(".")[1]),
-            int(current.syft_client_version.split(".")[2]),
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            compatible = ds_manager.peer_manager.get_compatible_peer_emails_for_syncing(
+                [do_manager.email]
+            )
+        assert do_manager.email in compatible
+        assert any("patch" in str(w.message).lower() for w in caught)
+
+    def test_patch_diff_skips_in_sync_for_do_default(self):
+        """DO-side default: patch differences cause the peer to be skipped."""
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
         )
-        patch_diff_version = build_client_version(f"{major}.{minor}.{patch + 1}")
-        _set_peer_version(do_manager, ds_manager.email, patch_diff_version)
+        _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
-        assert ds_manager.email in compatible
+        assert ds_manager.email not in compatible
         assert any("patch" in str(w.message).lower() for w in caught)
 
     def test_patch_diff_allows_job_submission(self):
+        """DS submitting to a patch-drifted DO does not raise (DS default = no skip)."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
-
-        current = VersionInfo.current()
-        parts = current.syft_client_version.split(".")
-        patch_diff_version = build_client_version(
-            f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}"
-        )
-        _set_peer_version(ds_manager, do_manager.email, patch_diff_version)
+        _set_peer_version(ds_manager, do_manager.email, _patch_plus_one_version())
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -370,6 +379,80 @@ class TestPatchTolerance:
             result.raise_on_skip(operation="submit job")
             result.maybe_warn()
         assert any("patch" in str(w.message).lower() for w in caught)
+
+    def test_patch_diff_do_force_ignore_proceeds(self):
+        """DO with force_ignore_peer_version proceeds despite patch drift."""
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
+        )
+        _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
+        do_manager.peer_manager.force_ignore_peer_version = True
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
+                [ds_manager.email]
+            )
+        assert ds_manager.email in compatible
+        assert any("proceeding anyway" in str(w.message).lower() for w in caught)
+
+    def test_patch_diff_do_per_call_ignore_proceeds(self):
+        """DO with per-call ignore_peer_version proceeds despite patch drift."""
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
+        )
+        _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
+
+        compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
+            [ds_manager.email], ignore_peer_version=True
+        )
+        assert ds_manager.email in compatible
+
+    def test_patch_diff_do_explicit_false_does_not_skip(self):
+        """Setting skip_on_patch_version_difference=False on a DO disables the skip."""
+        ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+            check_versions=True,
+        )
+        _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
+        do_manager.peer_manager.skip_on_patch_version_difference = False
+
+        compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
+            [ds_manager.email]
+        )
+        assert ds_manager.email in compatible
+
+
+class TestPeerManagerConfigPatchSkipDefault:
+    """Tests for the role-derived default of skip_on_patch_version_difference."""
+
+    def _make_config(self, **kwargs):
+        from pathlib import Path
+
+        from syft_client.sync.version.peer_manager import PeerManagerConfig
+
+        return PeerManagerConfig(syftbox_folder=Path("/tmp/syftbox"), **kwargs)
+
+    def test_do_defaults_to_skip(self):
+        cfg = self._make_config(has_do_role=True)
+        assert cfg.skip_on_patch_version_difference is True
+
+    def test_ds_only_defaults_to_no_skip(self):
+        cfg = self._make_config(has_ds_role=True)
+        assert cfg.skip_on_patch_version_difference is False
+
+    def test_dual_role_defaults_to_skip(self):
+        cfg = self._make_config(has_do_role=True, has_ds_role=True)
+        assert cfg.skip_on_patch_version_difference is True
+
+    def test_explicit_false_on_do_is_preserved(self):
+        cfg = self._make_config(
+            has_do_role=True, skip_on_patch_version_difference=False
+        )
+        assert cfg.skip_on_patch_version_difference is False
+
+    def test_explicit_true_on_ds_is_preserved(self):
+        cfg = self._make_config(has_ds_role=True, skip_on_patch_version_difference=True)
+        assert cfg.skip_on_patch_version_difference is True
 
 
 class TestForceAllowIncompatiblePeers:


### PR DESCRIPTION
## Summary
- Add `skip_on_patch_version_difference` to `PeerManagerConfig`, resolved by a `model_validator` to `True` for managers with a DO role and `False` for DS-only managers (override either way by passing the field explicitly).
- Treat `PATCH_DIFF` like `INCOMPATIBLE` in `PeerManager.get_peer_compatibility_status` when the flag is `True`: skip the peer unless `force_ignore_peer_version` (config-level) or per-call `ignore_peer_version` is set.
- DS-side behavior is unchanged (warn but never skip); DOs now refuse to sync/submit/execute against peers running a different patch version, matching the existing minor/major incompat handling.

## Test plan
- [x] `uv run pytest -n auto tests/unit/test_version_negotiation.py` — 40 passed (covers DS no-skip, DO default skip, DO + `force_ignore_peer_version`, DO + per-call `ignore_peer_version`, DO with explicit `skip_on_patch_version_difference=False`, and the config validator default for DO / DS / dual-role).
- [x] `just test-unit-fast` — 376 passed.