### PR TITLE
fix: route PeerCompatibilityResult.maybe_warn through logger.info

### DIFF
--- a/syft_client/__init__.py
+++ b/syft_client/__init__.py
@@ -7,15 +7,15 @@ from pathlib import Path
 
 # Default logging for the syft_client namespace. Only installs a handler if
 # nothing is already configured -- callers who set up their own logging keep
-# full control. propagate=False prevents double-printing when the root logger
-# also has a handler.
+# full control. Records still propagate to the root logger so test fixtures
+# (pytest's caplog) and user-configured root handlers can observe them; in
+# default Python the root logger has no handler so there's no double print.
 _logger = logging.getLogger("syft_client")
 if not _logger.handlers:
     _handler = logging.StreamHandler()
     _handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
     _logger.addHandler(_handler)
     _logger.setLevel(logging.INFO)
-    _logger.propagate = False
 
 from syft_client.version import SYFT_CLIENT_VERSION as __version__  # noqa: F401, E402
 from syft_client.sync.login import login_do, login_ds, login  # noqa: F401, E402

--- a/syft_client/__init__.py
+++ b/syft_client/__init__.py
@@ -2,21 +2,35 @@
 syft_client - A unified client for secure file syncing
 """
 
+import logging
 from pathlib import Path
-from syft_client.version import SYFT_CLIENT_VERSION as __version__  # noqa: F401
-from syft_client.sync.login import login_do, login_ds, login  # noqa: F401
-from syft_client.utils import (  # noqa: F401
+
+# Default logging for the syft_client namespace. Only installs a handler if
+# nothing is already configured -- callers who set up their own logging keep
+# full control. propagate=False prevents double-printing when the root logger
+# also has a handler.
+_logger = logging.getLogger("syft_client")
+if not _logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    _logger.addHandler(_handler)
+    _logger.setLevel(logging.INFO)
+    _logger.propagate = False
+
+from syft_client.version import SYFT_CLIENT_VERSION as __version__  # noqa: F401, E402
+from syft_client.sync.login import login_do, login_ds, login  # noqa: F401, E402
+from syft_client.utils import (  # noqa: F401, E402
     resolve_path,
     resolve_dataset_file_path,
     resolve_dataset_files_path,
     bug_report,
 )
-from syft_client.gdrive_utils import (  # noqa: F401
+from syft_client.gdrive_utils import (  # noqa: F401, E402
     download_from_gdrive,
     credentials_to_token,
     delete_remote_syftbox,
 )
-from syft_client.sync.utils.syftbox_utils import (  # noqa: F401
+from syft_client.sync.utils.syftbox_utils import (  # noqa: F401, E402
     delete_syftbox,
     delete_local_syftbox,
 )

--- a/syft_client/sync/version/peer_manager.py
+++ b/syft_client/sync/version/peer_manager.py
@@ -3,6 +3,7 @@ PeerManager for managing peers, version information, and compatibility checks.
 """
 
 import json
+import logging
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
@@ -28,6 +29,8 @@ from syft_client.sync.version.exceptions import (
     VersionUnknownError,
 )
 from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
+
+logger = logging.getLogger(__name__)
 
 
 class CompatAction(str, Enum):
@@ -55,8 +58,13 @@ class PeerCompatibilityResult(BaseModel):
     local_version: Optional[VersionInfo] = None
     peer_version: Optional[VersionInfo] = None
 
+    # TODO: rename `maybe_warn` -> `maybe_log` and `suppress_version_warnings`
+    # -> `suppress_version_logs`. The body now emits via logger.info() rather
+    # than warnings.warn(), so the "warn" naming is misleading. Held off on
+    # the rename to keep this change minimal; do it in a follow-up that
+    # updates the public API and all call sites.
     def maybe_warn(self) -> None:
-        """Emit a warning, picking explanation_skip vs explanation_not_skip.
+        """Emit an INFO log, picking explanation_skip vs explanation_not_skip.
 
         Appends an override hint only when skipping. Respects
         suppress_version_warnings.
@@ -65,11 +73,11 @@ class PeerCompatibilityResult(BaseModel):
             return
         elif self.should_skip:
             if self.explanation_skip:
-                warnings.warn(
+                logger.info(
                     f"{self.explanation_skip} Use ignore_peer_version=True to override."
                 )
         elif self.explanation_not_skip:
-            warnings.warn(self.explanation_not_skip)
+            logger.info(self.explanation_not_skip)
 
     def raise_on_skip(self, operation: str) -> None:
         """Raise the appropriate VersionError if `should_skip` is True."""

--- a/tests/unit/test_version_negotiation.py
+++ b/tests/unit/test_version_negotiation.py
@@ -1,6 +1,6 @@
 """Unit tests for version negotiation feature."""
 
-import warnings
+import logging
 
 import pytest
 from syft_client.sync.syftbox_manager import SyftboxManager
@@ -10,6 +10,22 @@ from syft_client.sync.version.exceptions import (
 )
 from syft_client.sync.version.peer_manager import CompatAction
 from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
+
+
+@pytest.fixture
+def syft_caplog(caplog):
+    """Capture log records emitted via the syft_client logger.
+
+    The package sets propagate=False on its logger so records don't reach
+    pytest's root-attached handler. We attach caplog's handler directly to
+    the syft_client logger for the test, then remove it.
+    """
+    syft_logger = logging.getLogger("syft_client")
+    syft_logger.addHandler(caplog.handler)
+    try:
+        yield caplog
+    finally:
+        syft_logger.removeHandler(caplog.handler)
 
 
 def build_client_version(client_version: str) -> VersionInfo:
@@ -328,7 +344,7 @@ def _set_peer_version(manager: SyftboxManager, peer_email: str, version: Version
 class TestPatchTolerance:
     """Tests that patch-only differences warn but don't block."""
 
-    def test_patch_diff_does_not_skip_in_sync(self):
+    def test_patch_diff_does_not_skip_in_sync(self, syft_caplog):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
@@ -342,15 +358,14 @@ class TestPatchTolerance:
         patch_diff_version = build_client_version(f"{major}.{minor}.{patch + 1}")
         _set_peer_version(do_manager, ds_manager.email, patch_diff_version)
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
             compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email in compatible
-        assert any("patch" in str(w.message).lower() for w in caught)
+        assert any("patch" in r.getMessage().lower() for r in syft_caplog.records)
 
-    def test_patch_diff_allows_job_submission(self):
+    def test_patch_diff_allows_job_submission(self, syft_caplog):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
@@ -362,14 +377,13 @@ class TestPatchTolerance:
         )
         _set_peer_version(ds_manager, do_manager.email, patch_diff_version)
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
             result = ds_manager.peer_manager.get_peer_compatibility_status(
                 do_manager.email, action=CompatAction.SUBMIT
             )
             result.raise_on_skip(operation="submit job")
             result.maybe_warn()
-        assert any("patch" in str(w.message).lower() for w in caught)
+        assert any("patch" in r.getMessage().lower() for r in syft_caplog.records)
 
 
 class TestForceAllowIncompatiblePeers:
@@ -387,20 +401,21 @@ class TestForceAllowIncompatiblePeers:
         )
         assert ds_manager.email not in compatible
 
-    def test_force_allow_includes_incompatible_peer(self):
+    def test_force_allow_includes_incompatible_peer(self, syft_caplog):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
         _set_peer_version(do_manager, ds_manager.email, build_client_version("99.0.0"))
 
         do_manager.peer_manager.force_ignore_peer_version = True
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
             compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email in compatible
-        assert any("proceeding anyway" in str(w.message).lower() for w in caught)
+        assert any(
+            "proceeding anyway" in r.getMessage().lower() for r in syft_caplog.records
+        )
 
     def test_per_call_ignore_peer_version_includes_peer(self):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(

--- a/tests/unit/test_version_negotiation.py
+++ b/tests/unit/test_version_negotiation.py
@@ -12,22 +12,6 @@ from syft_client.sync.version.peer_manager import CompatAction
 from syft_client.sync.version.version_info import CompatibilityStatus, VersionInfo
 
 
-@pytest.fixture
-def syft_caplog(caplog):
-    """Capture log records emitted via the syft_client logger.
-
-    The package sets propagate=False on its logger so records don't reach
-    pytest's root-attached handler. We attach caplog's handler directly to
-    the syft_client logger for the test, then remove it.
-    """
-    syft_logger = logging.getLogger("syft_client")
-    syft_logger.addHandler(caplog.handler)
-    try:
-        yield caplog
-    finally:
-        syft_logger.removeHandler(caplog.handler)
-
-
 def build_client_version(client_version: str) -> VersionInfo:
     """Build a VersionInfo for a given client version, leaving other fields as-current."""
     base = VersionInfo.current()
@@ -350,50 +334,50 @@ def _patch_plus_one_version() -> VersionInfo:
 class TestPatchTolerance:
     """Patch-only differences: DSes log but don't skip; DOs skip by default."""
 
-    def test_patch_diff_does_not_skip_in_sync_for_ds(self, syft_caplog):
+    def test_patch_diff_does_not_skip_in_sync_for_ds(self, caplog):
         """DS-side default: patch differences log but do not skip."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
         _set_peer_version(ds_manager, do_manager.email, _patch_plus_one_version())
 
-        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
+        with caplog.at_level(logging.INFO, logger="syft_client"):
             compatible = ds_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [do_manager.email]
             )
         assert do_manager.email in compatible
-        assert any("patch" in r.getMessage().lower() for r in syft_caplog.records)
+        assert any("patch" in r.getMessage().lower() for r in caplog.records)
 
-    def test_patch_diff_skips_in_sync_for_do_default(self, syft_caplog):
+    def test_patch_diff_skips_in_sync_for_do_default(self, caplog):
         """DO-side default: patch differences cause the peer to be skipped."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
         _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
 
-        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
+        with caplog.at_level(logging.INFO, logger="syft_client"):
             compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email not in compatible
-        assert any("patch" in r.getMessage().lower() for r in syft_caplog.records)
+        assert any("patch" in r.getMessage().lower() for r in caplog.records)
 
-    def test_patch_diff_allows_job_submission(self, syft_caplog):
+    def test_patch_diff_allows_job_submission(self, caplog):
         """DS submitting to a patch-drifted DO does not raise (DS default = no skip)."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
         _set_peer_version(ds_manager, do_manager.email, _patch_plus_one_version())
 
-        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
+        with caplog.at_level(logging.INFO, logger="syft_client"):
             result = ds_manager.peer_manager.get_peer_compatibility_status(
                 do_manager.email, action=CompatAction.SUBMIT
             )
             result.raise_on_skip(operation="submit job")
             result.maybe_warn()
-        assert any("patch" in r.getMessage().lower() for r in syft_caplog.records)
+        assert any("patch" in r.getMessage().lower() for r in caplog.records)
 
-    def test_patch_diff_do_force_ignore_proceeds(self, syft_caplog):
+    def test_patch_diff_do_force_ignore_proceeds(self, caplog):
         """DO with force_ignore_peer_version proceeds despite patch drift."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
@@ -401,13 +385,13 @@ class TestPatchTolerance:
         _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
         do_manager.peer_manager.force_ignore_peer_version = True
 
-        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
+        with caplog.at_level(logging.INFO, logger="syft_client"):
             compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email in compatible
         assert any(
-            "proceeding anyway" in r.getMessage().lower() for r in syft_caplog.records
+            "proceeding anyway" in r.getMessage().lower() for r in caplog.records
         )
 
     def test_patch_diff_do_per_call_ignore_proceeds(self):
@@ -484,20 +468,20 @@ class TestForceAllowIncompatiblePeers:
         )
         assert ds_manager.email not in compatible
 
-    def test_force_allow_includes_incompatible_peer(self, syft_caplog):
+    def test_force_allow_includes_incompatible_peer(self, caplog):
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
         _set_peer_version(do_manager, ds_manager.email, build_client_version("99.0.0"))
 
         do_manager.peer_manager.force_ignore_peer_version = True
-        with syft_caplog.at_level(logging.INFO, logger="syft_client"):
+        with caplog.at_level(logging.INFO, logger="syft_client"):
             compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
                 [ds_manager.email]
             )
         assert ds_manager.email in compatible
         assert any(
-            "proceeding anyway" in r.getMessage().lower() for r in syft_caplog.records
+            "proceeding anyway" in r.getMessage().lower() for r in caplog.records
         )
 
     def test_per_call_ignore_peer_version_includes_peer(self):


### PR DESCRIPTION
## Summary
- `PeerCompatibilityResult.maybe_warn` now emits via `logger.info(...)` instead of `warnings.warn(...)`. Standard logging gives callers control over visibility without juggling `warnings.filterwarnings`, and `INFO` level matches the semantics: this is "letting you know," not "something's wrong."
- Add a default `StreamHandler` on the `syft_client` logger in `syft_client/__init__.py` so the message is visible in notebooks out of the box. The handler is installed only if no handler exists (respecting user-configured logging) and `propagate=False` prevents double-printing through the root logger.
- Convert 3 tests from `warnings.catch_warnings` to `caplog`, with a new `syft_caplog` fixture that attaches caplog's handler to the `syft_client` logger so `propagate=False` doesn't block capture.

## Why
`warnings.warn(...)` produces a yellow `UserWarning` in Jupyter that's hard to silence selectively and reads as "something's wrong." For version-drift notices that are informational ("we're not skipping this peer, FYI"), an INFO log is a better fit.

In Jupyter, the new handler binds to `sys.stderr` (captured by IPython's `OutStream` at import time), so messages still render in cell output — pink-tinted like before, but tagged `[INFO]` instead of `UserWarning`.

## What's intentionally not changed
- `maybe_warn` is **not** renamed yet to `maybe_log`, and `suppress_version_warnings` is **not** renamed yet to `suppress_version_logs`. Both touch all call sites; held off to keep this diff minimal. A `TODO` is left at the method documenting the planned rename for a follow-up.
- The two other `warnings.warn(...)` call sites in `peer_manager.py` (lines 213, 363) outside `maybe_warn` are untouched.

## Test plan
- [x] `pytest tests/unit/test_version_negotiation.py` — 31/31 pass
- [x] End-to-end Jupyter test (executed a one-cell notebook via `nbclient`): with the realistic import path `from syft_client import login_ds, login_do`, the `[INFO]` line appears as `stream='stderr'` in cell output. Verified skipping (with override hint), not-skipping (no override hint), and suppressed (silent) cases all behave as expected.

## Expected user-facing change
Before: `UserWarning: Peer alice@example.com has incompatible version Use ignore_peer_version=True to override.`

After: `[INFO] Peer alice@example.com has incompatible version Use ignore_peer_version=True to override.`

Both render pink-tinted in Jupyter (stderr).