### PR TITLE
fix: add delay after PyPI poll for CDN propagation

### DIFF
--- a/.github/workflows/post-release-tests.yml
+++ b/.github/workflows/post-release-tests.yml
@@ -44,6 +44,9 @@ jobs:
           echo "Timed out waiting for syft-client==${VERSION} on PyPI"
           exit 1
 
+      - name: Wait for PyPI CDN propagation
+        run: sleep 30
+
       - name: Install syft-client from PyPI
         run: |
           uv venv .venv


### PR DESCRIPTION
## Summary
- Adds a 30s sleep between the PyPI availability poll and `uv pip install` in the post-release test workflow
- Fixes a race condition where PyPI returns HTTP 200 for the version metadata but the package files haven't propagated to CDN edges yet, causing the install to fail