### PR TITLE
feat: expose peer version overrides via login and syft_bg

### DIFF
--- a/packages/syft-bg/src/syft_bg/approve/config.py
+++ b/packages/syft-bg/src/syft_bg/approve/config.py
@@ -73,6 +73,10 @@ class AutoApproveConfig(BaseModel):
     interval: int = 5
     auto_approvals: AutoApprovalsConfig = Field(default_factory=AutoApprovalsConfig)
     peers: PeerApprovalConfig = Field(default_factory=PeerApprovalConfig)
+    skip_peer_on_patch_version_diff: Optional[bool] = (
+        None  # None: value is determined by the role
+    )
+    force_ignore_peer_version: bool = False
 
     @classmethod
     def load(cls, config_path: Optional[Path] = None) -> "AutoApproveConfig":
@@ -102,6 +106,12 @@ class AutoApproveConfig(BaseModel):
             "peers": PeerApprovalConfig(**peers_data)
             if peers_data
             else PeerApprovalConfig(),
+            "skip_peer_on_patch_version_diff": approve_section.get(
+                "skip_peer_on_patch_version_diff"
+            ),
+            "force_ignore_peer_version": approve_section.get(
+                "force_ignore_peer_version", False
+            ),
         }
         if common.get("do_email"):
             kwargs["do_email"] = common["do_email"]
@@ -137,6 +147,8 @@ class AutoApproveConfig(BaseModel):
             "interval": self.interval,
             "auto_approvals": self.auto_approvals.model_dump(),
             "peers": self.peers.model_dump(),
+            "skip_peer_on_patch_version_diff": self.skip_peer_on_patch_version_diff,
+            "force_ignore_peer_version": self.force_ignore_peer_version,
         }
 
         with open(config_path, "w") as f:

--- a/packages/syft-bg/src/syft_bg/approve/orchestrator.py
+++ b/packages/syft-bg/src/syft_bg/approve/orchestrator.py
@@ -81,12 +81,16 @@ class ApprovalOrchestrator(BaseOrchestrator):
             client = SyftboxManager.for_colab(
                 email=config.do_email,
                 has_do_role=True,
+                skip_peer_on_patch_version_diff=config.skip_peer_on_patch_version_diff,
+                force_ignore_peer_version=config.force_ignore_peer_version,
             )
         else:
             client = SyftboxManager.for_jupyter(
                 email=config.do_email,
                 has_do_role=True,
                 token_path=config.drive_token_path,
+                skip_peer_on_patch_version_diff=config.skip_peer_on_patch_version_diff,
+                force_ignore_peer_version=config.force_ignore_peer_version,
             )
 
         return cls(client=client, config=config)

--- a/packages/syft-bg/src/syft_bg/sync/config.py
+++ b/packages/syft-bg/src/syft_bg/sync/config.py
@@ -20,3 +20,7 @@ class SyncConfig(BaseModel):
     sync_state_path: Path = Field(
         default_factory=lambda: get_default_paths().sync_state
     )
+    skip_peer_on_patch_version_diff: Optional[bool] = (
+        None  # None: value is determined by the role
+    )
+    force_ignore_peer_version: bool = False

--- a/packages/syft-bg/src/syft_bg/sync/orchestrator.py
+++ b/packages/syft-bg/src/syft_bg/sync/orchestrator.py
@@ -51,12 +51,16 @@ class SyncOrchestrator(BaseOrchestrator):
             client = SyftboxManager.for_colab(
                 email=config.do_email,
                 has_do_role=True,
+                skip_peer_on_patch_version_diff=config.skip_peer_on_patch_version_diff,
+                force_ignore_peer_version=config.force_ignore_peer_version,
             )
         else:
             client = SyftboxManager.for_jupyter(
                 email=config.do_email,
                 has_do_role=True,
                 token_path=config.drive_token_path,
+                skip_peer_on_patch_version_diff=config.skip_peer_on_patch_version_diff,
+                force_ignore_peer_version=config.force_ignore_peer_version,
             )
 
         state = JsonStateManager(config.sync_state_path)

--- a/syft_client/sync/login.py
+++ b/syft_client/sync/login.py
@@ -69,8 +69,16 @@ def login(
     sync: bool = True,
     load_peers: bool = True,
     token_path: str | Path | None = None,
+    skip_peer_on_patch_version_diff: bool
+    | None = None,  # None: value is determined by the role
 ):
-    return login_ds(email, sync, load_peers, token_path)
+    return login_ds(
+        email,
+        sync,
+        load_peers,
+        token_path,
+        skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+    )
 
 
 def login_ds(
@@ -78,6 +86,8 @@ def login_ds(
     sync: bool = True,
     load_peers: bool = True,
     token_path: str | Path | None = None,
+    skip_peer_on_patch_version_diff: bool
+    | None = None,  # None: value is determined by the role
 ):
     env = check_env()
     email, token_path = _resolve_login_params(email, token_path)
@@ -85,10 +95,17 @@ def login_ds(
     handle_potential_version_mismatches_on_login(email, token_path)
 
     if env == Environment.COLAB:
-        client = SyftboxManager.for_colab(email=email, has_ds_role=True)
+        client = SyftboxManager.for_colab(
+            email=email,
+            has_ds_role=True,
+            skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+        )
     else:
         client = SyftboxManager.for_jupyter(
-            email=email, has_ds_role=True, token_path=token_path
+            email=email,
+            has_ds_role=True,
+            token_path=token_path,
+            skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
         )
 
     return _init_client_login(client, sync, load_peers)
@@ -99,6 +116,8 @@ def login_do(
     sync: bool = True,
     load_peers: bool = True,
     token_path: str | Path | None = None,
+    skip_peer_on_patch_version_diff: bool
+    | None = None,  # None: value is determined by the role
 ):
     env = check_env()
     email, token_path = _resolve_login_params(email, token_path)
@@ -106,10 +125,17 @@ def login_do(
     handle_potential_version_mismatches_on_login(email, token_path)
 
     if env == Environment.COLAB:
-        client = SyftboxManager.for_colab(email=email, has_do_role=True)
+        client = SyftboxManager.for_colab(
+            email=email,
+            has_do_role=True,
+            skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+        )
     else:
         client = SyftboxManager.for_jupyter(
-            email=email, has_do_role=True, token_path=token_path
+            email=email,
+            has_do_role=True,
+            token_path=token_path,
+            skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
         )
 
     return _init_client_login(client, sync, load_peers)

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -18,7 +18,7 @@ from syft_datasets.config import SyftBoxConfig
 from syft_datasets.dataset_manager import SyftDatasetManager
 from syft_client.sync.platforms.base_platform import BasePlatform
 from pydantic import BaseModel, PrivateAttr
-from typing import List, cast
+from typing import List, Optional, cast
 from syft_client.sync.sync.caches.datasite_watcher_cache import (
     DataSiteWatcherCacheConfig,
 )
@@ -100,7 +100,14 @@ class SyftboxManagerConfig(BaseModel):
 
     @classmethod
     def for_colab(
-        cls, email: str, has_ds_role: bool = False, has_do_role: bool = False
+        cls,
+        email: str,
+        has_ds_role: bool = False,
+        has_do_role: bool = False,
+        skip_peer_on_patch_version_diff: Optional[
+            bool
+        ] = None,  # None: value is determined by the role
+        force_ignore_peer_version: bool = False,
     ):
         if not has_ds_role and not has_do_role:
             raise ValueError("At least one of has_ds_role or has_do_role must be True")
@@ -147,6 +154,8 @@ class SyftboxManagerConfig(BaseModel):
             connection_configs=connection_configs,
             has_do_role=has_do_role,
             has_ds_role=has_ds_role,
+            skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+            force_ignore_peer_version=force_ignore_peer_version,
         )
         return cls(
             email=email,
@@ -169,6 +178,10 @@ class SyftboxManagerConfig(BaseModel):
         has_ds_role: bool = False,
         has_do_role: bool = False,
         token_path: Path | None = None,
+        skip_peer_on_patch_version_diff: Optional[
+            bool
+        ] = None,  # None: value is determined by the role
+        force_ignore_peer_version: bool = False,
     ):
         if not has_ds_role and not has_do_role:
             raise ValueError("At least one of has_ds_role or has_do_role must be True")
@@ -218,6 +231,8 @@ class SyftboxManagerConfig(BaseModel):
             connection_configs=connection_configs,
             has_do_role=has_do_role,
             has_ds_role=has_ds_role,
+            skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+            force_ignore_peer_version=force_ignore_peer_version,
         )
         return cls(
             email=email,
@@ -544,12 +559,18 @@ class SyftboxManager(BaseModel):
         has_do_role: bool = False,
         encryption: bool = False,
         encryption_keys: dict | None = None,
+        skip_peer_on_patch_version_diff: Optional[
+            bool
+        ] = None,  # None: value is determined by the role
+        force_ignore_peer_version: bool = False,
     ):
         manager = cls.from_config(
             SyftboxManagerConfig.for_colab(
                 email=email,
                 has_ds_role=has_ds_role,
                 has_do_role=has_do_role,
+                skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+                force_ignore_peer_version=force_ignore_peer_version,
             )
         )
         manager._init_encryption(encryption, encryption_keys)
@@ -584,6 +605,10 @@ class SyftboxManager(BaseModel):
         token_path: Path | None = None,
         encryption: bool = False,
         encryption_keys: dict | None = None,
+        skip_peer_on_patch_version_diff: Optional[
+            bool
+        ] = None,  # None: value is determined by the role
+        force_ignore_peer_version: bool = False,
     ):
         if token_path is not None:
             token_path = Path(token_path)
@@ -593,6 +618,8 @@ class SyftboxManager(BaseModel):
                 has_ds_role=has_ds_role,
                 has_do_role=has_do_role,
                 token_path=token_path,
+                skip_peer_on_patch_version_diff=skip_peer_on_patch_version_diff,
+                force_ignore_peer_version=force_ignore_peer_version,
             )
         )
         manager._init_encryption(encryption, encryption_keys)

--- a/syft_client/sync/version/peer_manager.py
+++ b/syft_client/sync/version/peer_manager.py
@@ -104,14 +104,14 @@ class PeerManagerConfig(BaseModel):
     has_do_role: bool = False
     has_ds_role: bool = False
     use_encryption: bool = False
-    # None means "default by role" — resolved in the model_validator below
-    # to True for DOs (has_do_role) and False for DS-only managers.
-    skip_on_patch_version_difference: Optional[bool] = None
+    skip_peer_on_patch_version_diff: Optional[bool] = (
+        None  # None: value is determined by the role (resolves to has_do_role)
+    )
 
     @model_validator(mode="after")
-    def _default_skip_on_patch(self) -> "PeerManagerConfig":
-        if self.skip_on_patch_version_difference is None:
-            self.skip_on_patch_version_difference = self.has_do_role
+    def _default_skip_peer_on_patch(self) -> "PeerManagerConfig":
+        if self.skip_peer_on_patch_version_diff is None:
+            self.skip_peer_on_patch_version_diff = self.has_do_role
         return self
 
 
@@ -129,7 +129,7 @@ class PeerManager(BaseModel):
     n_threads: int = 10
     has_do_role: bool = False
     has_ds_role: bool = False
-    skip_on_patch_version_difference: bool = False
+    skip_peer_on_patch_version_diff: bool = False
 
     _own_version: Optional[VersionInfo] = PrivateAttr(default=None)
     _executor: Optional[ThreadPoolExecutor] = PrivateAttr(default=None)
@@ -178,8 +178,8 @@ class PeerManager(BaseModel):
             n_threads=config.n_threads,
             has_do_role=config.has_do_role,
             has_ds_role=config.has_ds_role,
-            skip_on_patch_version_difference=bool(
-                config.skip_on_patch_version_difference
+            skip_peer_on_patch_version_diff=bool(
+                config.skip_peer_on_patch_version_diff
             ),
         )
 
@@ -309,7 +309,7 @@ class PeerManager(BaseModel):
                 if peer_version is not None
                 else None
             )
-            if self.skip_on_patch_version_difference:
+            if self.skip_peer_on_patch_version_diff:
                 effective_ignore = self.force_ignore_peer_version or ignore_peer_version
                 if effective_ignore:
                     return PeerCompatibilityResult(

--- a/tests/unit/test_version_negotiation.py
+++ b/tests/unit/test_version_negotiation.py
@@ -407,12 +407,12 @@ class TestPatchTolerance:
         assert ds_manager.email in compatible
 
     def test_patch_diff_do_explicit_false_does_not_skip(self):
-        """Setting skip_on_patch_version_difference=False on a DO disables the skip."""
+        """Setting skip_peer_on_patch_version_diff=False on a DO disables the skip."""
         ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
             check_versions=True,
         )
         _set_peer_version(do_manager, ds_manager.email, _patch_plus_one_version())
-        do_manager.peer_manager.skip_on_patch_version_difference = False
+        do_manager.peer_manager.skip_peer_on_patch_version_diff = False
 
         compatible = do_manager.peer_manager.get_compatible_peer_emails_for_syncing(
             [ds_manager.email]
@@ -421,7 +421,7 @@ class TestPatchTolerance:
 
 
 class TestPeerManagerConfigPatchSkipDefault:
-    """Tests for the role-derived default of skip_on_patch_version_difference."""
+    """Tests for the role-derived default of skip_peer_on_patch_version_diff."""
 
     def _make_config(self, **kwargs):
         from pathlib import Path
@@ -432,25 +432,23 @@ class TestPeerManagerConfigPatchSkipDefault:
 
     def test_do_defaults_to_skip(self):
         cfg = self._make_config(has_do_role=True)
-        assert cfg.skip_on_patch_version_difference is True
+        assert cfg.skip_peer_on_patch_version_diff is True
 
     def test_ds_only_defaults_to_no_skip(self):
         cfg = self._make_config(has_ds_role=True)
-        assert cfg.skip_on_patch_version_difference is False
+        assert cfg.skip_peer_on_patch_version_diff is False
 
     def test_dual_role_defaults_to_skip(self):
         cfg = self._make_config(has_do_role=True, has_ds_role=True)
-        assert cfg.skip_on_patch_version_difference is True
+        assert cfg.skip_peer_on_patch_version_diff is True
 
     def test_explicit_false_on_do_is_preserved(self):
-        cfg = self._make_config(
-            has_do_role=True, skip_on_patch_version_difference=False
-        )
-        assert cfg.skip_on_patch_version_difference is False
+        cfg = self._make_config(has_do_role=True, skip_peer_on_patch_version_diff=False)
+        assert cfg.skip_peer_on_patch_version_diff is False
 
     def test_explicit_true_on_ds_is_preserved(self):
-        cfg = self._make_config(has_ds_role=True, skip_on_patch_version_difference=True)
-        assert cfg.skip_on_patch_version_difference is True
+        cfg = self._make_config(has_ds_role=True, skip_peer_on_patch_version_diff=True)
+        assert cfg.skip_peer_on_patch_version_diff is True
 
 
 class TestForceAllowIncompatiblePeers:


### PR DESCRIPTION
## Summary
- Rename `PeerManagerConfig.skip_on_patch_version_difference` → `skip_peer_on_patch_version_diff`.
- `SyftboxManager.for_colab` / `for_jupyter` now accept `skip_peer_on_patch_version_diff` and `force_ignore_peer_version`, threaded into `PeerManagerConfig`.
- `login_do` / `login_ds` / `login` expose `skip_peer_on_patch_version_diff` only.
- `SyncConfig` and `AutoApproveConfig` persist both fields; sync + approve orchestrators forward them into the `SyftboxManager` they build. No `syft_bg.init` signature change — values flow through the existing `settings={...}` dict.

## Test plan
- [x] `login_do(..., skip_peer_on_patch_version_diff=False)` → `client.peer_manager.skip_peer_on_patch_version_diff is False` (overrides DO default of True).
- [x] `syft_bg.reset` → `syft_bg.init(do_email=..., settings={"sync": {...}, "approve": {...}})` → `SyftBgConfig.from_path()` round-trips both fields for both services.
- [x] `syft_bg.ensure_running({"sync": {}, "approve": {}}, restart=True)` and both daemons log the override values (debug-printed during manual verification, since removed).
- [x] `pre-commit run --all-files` green.