### PR TITLE
fix: only log sync lock acquisition when contended

### DIFF
--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -920,14 +920,16 @@ class SyftboxManager(BaseModel):
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         lock_path.touch(exist_ok=True)
         with open(lock_path, "r") as lock_handle:
-            logger.info(f"Acquiring sync lock for {self.email}...")
             try:
-                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
-                logger.info(f"Sync lock acquired for {self.email}")
+                try:
+                    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    logger.info(f"Waiting for sync lock for {self.email}...")
+                    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+                    logger.info(f"Sync lock acquired for {self.email}")
                 yield
             finally:
                 fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
-                logger.info(f"Sync lock released for {self.email}")
 
     def sync(
         self,


### PR DESCRIPTION
## Summary
- `_sync_file_lock` now attempts a non-blocking `fcntl.flock(LOCK_EX | LOCK_NB)` first. The common, uncontended sync path stays silent.
- If another process holds the lock, we fall back to a blocking acquire and log `Waiting for sync lock...` / `Sync lock acquired...`.
- Background: the sync-lock INFO lines were added in `fe26843` (2026-04-15) but only became visible after #282 (2026-05-13) attached a `StreamHandler` to the `syft_client` logger. They started flooding interactive/background sync output.

## Test plan
- [ ] Run a normal `client.sync()` in a notebook — no `[INFO]` lines from the sync lock.
- [ ] Trigger contention (e.g. concurrent `sync()` from `syft-bg` and the notebook) and confirm the `Waiting for sync lock...` / `Sync lock acquired...` lines appear only on the waiter.