### PR TITLE
docs(enclave): drop zone arg from recipes; configure via init only

### DIFF
--- a/packages/syft-enclave/Justfile
+++ b/packages/syft-enclave/Justfile
@@ -3,19 +3,19 @@ image := "docker.io/openminedreleasebot/syft-client-enclave:latest"
 machine_type_default := "n2d-standard-2"
 vm_default := "syft-enclave-vm"
 
-# Shared shell snippet: loads project_id and zone_default from ~/syft-enclaves/settings.json.
+# Shared shell snippet: loads project_id and zone from ~/syft-enclaves/settings.json.
 # Interpolated as {{load_settings}} at the top of every recipe that needs them.
 load_settings := 'settings="$HOME/syft-enclaves/settings.json"
 [ -f "$settings" ] || { echo "Error: $settings not found. Run: just init <project_id>" >&2; exit 1; }
 project_id=$(jq -r .project_id "$settings")
-zone_default=$(jq -r .zone "$settings")'
+zone=$(jq -r .zone "$settings")'
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Settings
 #
 # `init` writes ~/syft-enclaves/settings.json with project_id and zone. Every other
-# recipe reads project_id from that file. Zone resolution: explicit `zone=` arg wins,
-# otherwise fall back to settings.json's zone. Run `just init <project_id>` first.
+# recipe reads both from that file — there is no per-call zone override. To switch
+# zones, re-run `just init <project_id> <zone>`.
 # ---------------------------------------------------------------------------------------------------------------------
 
 # Initialize ~/syft-enclaves/settings.json and set gcloud's active project
@@ -67,12 +67,10 @@ _provision: _whoami
 
 # Deploy a production enclave VM (hardened image, no SSH)
 [group('deploy')]
-start name=vm_default zone="" machine_type=machine_type_default: _provision
+start name=vm_default machine_type=machine_type_default: _provision
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute instances create {{name}} \
       --project="$project_id" \
       --zone="$zone" \
@@ -89,12 +87,10 @@ start name=vm_default zone="" machine_type=machine_type_default: _provision
 
 # Deploy a debug enclave VM (SSH + container log redirection enabled)
 [group('deploy')]
-start-debug name=vm_default zone="" machine_type=machine_type_default: _provision
+start-debug name=vm_default machine_type=machine_type_default: _provision
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute instances create {{name}} \
       --project="$project_id" \
       --zone="$zone" \
@@ -111,12 +107,10 @@ start-debug name=vm_default zone="" machine_type=machine_type_default: _provisio
 
 # Delete the enclave VM and remove the firewall rule
 [group('teardown')]
-stop name=vm_default zone="": _whoami
+stop name=vm_default: _whoami
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute instances delete {{name}} \
       --project="$project_id" \
       --zone="$zone" \
@@ -127,12 +121,10 @@ stop name=vm_default zone="": _whoami
 
 # Print the VM's external IP
 [group('inspect')]
-get-ip name=vm_default zone="": _whoami
+get-ip name=vm_default: _whoami
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute instances describe {{name}} \
       --project="$project_id" \
       --zone="$zone" \
@@ -140,12 +132,10 @@ get-ip name=vm_default zone="": _whoami
 
 # Print the VM's current status (RUNNING / TERMINATED / etc.)
 [group('inspect')]
-status name=vm_default zone="": _whoami
+status name=vm_default: _whoami
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute instances describe {{name}} \
       --project="$project_id" \
       --zone="$zone" \
@@ -153,24 +143,20 @@ status name=vm_default zone="": _whoami
 
 # Tail the last 50 lines of the VM's serial port output
 [group('inspect')]
-logs name=vm_default zone="": _whoami
+logs name=vm_default: _whoami
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute instances get-serial-port-output {{name}} \
       --project="$project_id" \
       --zone="$zone" 2>&1 | tail -50
 
 # SSH into the VM (only works on debug image)
 [group('inspect')]
-ssh name=vm_default zone="": _whoami
+ssh name=vm_default: _whoami
     #!/bin/bash
     set -e
     {{load_settings}}
-    zone="{{zone}}"
-    zone="${zone:-$zone_default}"
     gcloud compute ssh {{name}} \
       --project="$project_id" \
       --zone="$zone"

--- a/packages/syft-enclave/README.md
+++ b/packages/syft-enclave/README.md
@@ -9,6 +9,8 @@ Enclave support for syft-client, enabling secure computation in Trusted Executio
 
 ## Dev
 
+**note: `[arg]` syntax in this document means that `arg` is optional (with default)**
+
 ```
 uv pip install -e .
 ```
@@ -28,46 +30,46 @@ All deploy / inspect / teardown commands below are `just` recipes defined in [`.
 just init YOUR_PROJECT_ID
 ```
 
-This stores `project_id` (and zone, default `us-central1-a`) in `~/syft-enclaves/settings.json`, and runs `gcloud config set project`. Every other recipe reads `project_id` from this file. Pass a custom zone with `just init YOUR_PROJECT_ID europe-west4-a`.
+This stores settings in `~/syft-enclaves/settings.json` and sets the active gcloud project. Every other recipe reads `project_id` and `zone` from this file — zone is **not** a per-call arg. To deploy in a different zone, re-run `just init YOUR_PROJECT_ID europe-west4-a`.
 
 ### Production deployment
 
-For production, use the hardened image. This disables SSH, log redirection, and debugging.
+#### Start
+
+`just start` runs the one-time provisioning steps and then creates a Confidential Space VM
 
 ```bash
-just start                                # defaults: syft-enclave-vm, n2d-standard-2
-just start my-vm europe-west4-a n2d-standard-4   # override name / zone / machine type
+just start                          # defaults: syft-enclave-vm, n2d-standard-2
+just start my-vm n2d-standard-4     # override name / machine type
 ```
 
-`just start` runs the one-time provisioning steps (enable APIs, grant the default compute service account `roles/confidentialcomputing.workloadUser`, create the `allow-enclave-http` firewall rule on tcp:8080) and then creates a Confidential Space VM running the image at `docker.io/openminedreleasebot/syft-client-enclave:latest`.
+#### stop
 
-Production image differences:
+```bash
+just stop [name]
+```
+
+Deletes the VM and all related objects.
+
+### Inspect a running VM
+
+Each of these takes an optional `name` (default: `syft-enclave-vm`). Zone is always read from `settings.json`.
+
+```bash
+just status [name]   # RUNNING / TERMINATED / etc.
+just get-ip [name]   # external IP
+just logs   [name]   # last 50 lines of serial output
+just ssh    [name]   # debug image only
+```
+
+## Debugging
+
+Production image features:
 
 - No SSH access
 - No container log redirection (serial logs only show launcher output)
 - `tee-restart-policy=Never` shuts down the VM if the container exits
 - `Hardened:true` in attestation claims
-
-### Inspect a running VM
-
-Each of these takes an optional `name` and `zone` (defaults: `syft-enclave-vm` and the zone from `settings.json`):
-
-```bash
-just status [name] [zone]   # RUNNING / TERMINATED / etc.
-just get-ip [name] [zone]   # external IP
-just logs   [name] [zone]   # last 50 lines of serial output
-just ssh    [name] [zone]   # debug image only
-```
-
-## Debugging
-
-### Debug deployment (recommended for initial setup)
-
-The debug image allows SSH access and container log redirection to serial output, making it easier to troubleshoot issues.
-
-```bash
-just start-debug
-```
 
 Debug image features:
 
@@ -76,13 +78,13 @@ Debug image features:
 - `tee-restart-policy=Always` keeps the VM running if the container crashes
 - `tee-container-log-redirect=true` redirects container logs to serial output
 
-## Cleanup
+### Debug deployment (recommended for initial setup)
+
+The debug image allows SSH access and container log redirection to serial output, making it easier to troubleshoot issues.
 
 ```bash
-just stop [name] [zone]
+just start-debug
 ```
-
-Deletes the VM and removes the `allow-enclave-http` firewall rule. The firewall rule is recreated automatically the next time you run `just start` or `just start-debug`.
 
 ## Building & pushing a new Docker Image
 


### PR DESCRIPTION
- Removed `zone` arg from `start`, `start-debug`, `stop`, `get-ip`, `status`, `logs`, `ssh`. Zone is now read exclusively from `~/syft-enclaves/settings.json`; switching zones means re-running `just init <project_id> <zone>`.
- README updated to reflect the new arg surface and clarify the zone-via-init model.