### PR TITLE
feat: DO advertises syft-client install source via VersionInfo

### DIFF
--- a/notebooks/beach/internal/DO_Tutorial_V3.ipynb
+++ b/notebooks/beach/internal/DO_Tutorial_V3.ipynb
@@ -1119,11 +1119,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/enclave/nanolm/3. enclave_eval_e2e.ipynb
+++ b/notebooks/enclave/nanolm/3. enclave_eval_e2e.ipynb
@@ -589,11 +589,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "syft-client (3.12.8)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/packages/syft-enclave/src/syft_enclaves/enclave_job_client.py
+++ b/packages/syft-enclave/src/syft_enclaves/enclave_job_client.py
@@ -24,6 +24,10 @@ class EnclaveJobClient(BaseJobClient):
     def current_user_email(self):
         return self._job_client.current_user_email
 
+    @property
+    def peer_install_sources(self) -> dict[str, str]:
+        return self._job_client.peer_install_sources
+
     def submit_bash_job(self, user: str, script: str, job_name: str = "") -> Path:
         return self._job_client.submit_bash_job(user, script, job_name)
 

--- a/packages/syft-job/src/syft_job/client.py
+++ b/packages/syft-job/src/syft_job/client.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
@@ -65,6 +66,9 @@ class JobClient(BaseJobClient):
             target_datasite_owner_email or config.current_user_email
         )  # The email of the datasite owner of the jobs
         self.has_do_role = config.has_do_role
+        self.peer_install_sources: dict[
+            str, str
+        ] = {}  # do_email -> syft-client install source (local path, git URL, or "syft-client==X.Y.Z") advertised by that DO in their VersionInfo
 
         # Validate that user_email exists in SyftBox root
         self._validate_user_email()
@@ -275,8 +279,35 @@ class JobClient(BaseJobClient):
 
         return resolved_path, is_folder_submission, entrypoint
 
+    def _resolve_install_source_for(self, do_email: str) -> str:
+        """Return the syft-client install source to bake into a job's run.sh.
+
+        Prefers the source advertised by the DO during peer-version exchange
+        (stored on `self.peer_install_sources`). Falls back to local detection
+        with a loud warning if the DO never advertised one (e.g. older client).
+        """
+        advertised = self.peer_install_sources.get(do_email)
+        if advertised:
+            return advertised
+
+        fallback = get_syft_client_install_source()
+        warnings.warn(
+            f"\n{'=' * 78}\n"
+            f"WARNING: No syft-client install source advertised by DO {do_email!r}.\n"
+            f"Falling back to local detection on the DS side: {fallback!r}.\n"
+            f"The DO may be running an older syft-client; the job may fail to\n"
+            f"install dependencies on the DO's machine.\n"
+            f"{'=' * 78}",
+            stacklevel=3,
+        )
+        return fallback
+
     def _generate_python_run_script(
-        self, entrypoint_path: str, dependencies: List[str], has_pyproject: bool
+        self,
+        entrypoint_path: str,
+        dependencies: List[str],
+        has_pyproject: bool,
+        install_source: str,
     ) -> str:
         """
         Generate bash script for Python job execution.
@@ -285,11 +316,12 @@ class JobClient(BaseJobClient):
             entrypoint_path: Filename to execute (e.g., "main.py" or "script.py")
             dependencies: List of dependencies to install
             has_pyproject: Whether the code has a pyproject.toml
+            install_source: Syft-client install source to use (pip/uv-compatible string).
 
         Returns:
             Bash script content
         """
-        all_dependencies = [get_syft_client_install_source()] + dependencies
+        all_dependencies = [install_source] + dependencies
 
         if has_pyproject:
             # For projects with pyproject.toml, run uv sync inside the code folder
@@ -396,11 +428,15 @@ python {entrypoint_path}
             shutil.copy2(code_path_resolved, code_dest / code_path_resolved.name)
             pyproject_path = None
 
+        # Resolve install source: prefer what the DO advertised in their VersionInfo,
+        # fall back to local detection with a warning if the DO didn't advertise one.
+        install_source = self._resolve_install_source_for(submitting_to_email)
+
         # Generate bash script for Python execution
         dependencies = dependencies or []
         has_pyproject = pyproject_path is not None and pyproject_path.exists()
         bash_script = self._generate_python_run_script(
-            entrypoint, dependencies, has_pyproject
+            entrypoint, dependencies, has_pyproject, install_source
         )
 
         # Create run.sh file
@@ -414,7 +450,7 @@ python {entrypoint_path}
         ]
 
         # Compute all_dependencies for config
-        all_dependencies = [get_syft_client_install_source()] + dependencies
+        all_dependencies = [install_source] + dependencies
 
         # Write config.yaml using model
         config = JobSubmissionMetadata(

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -799,6 +799,9 @@ class SyftboxManager(BaseModel):
             # DO approves the peer request
             do_manager.load_peers()
             do_manager.approve_peer_request(ds_manager.email)
+            # DS refreshes peer state so it sees DO's accepted status and
+            # DO's advertised VersionInfo (incl. syft_client_install_source).
+            ds_manager.load_peers()
 
         return ds_manager, do_manager
 
@@ -817,6 +820,7 @@ class SyftboxManager(BaseModel):
     ):
         """Add a peer. Delegates to PeerManager."""
         self.peer_manager.add_peer(peer_email, force=force, verbose=verbose)
+        self._sync_peer_install_sources_to_job_client()
         if self.has_do_role:
             self._post_approve_peer_do(peer_email)
         if sync:
@@ -989,6 +993,7 @@ class SyftboxManager(BaseModel):
                 instead of using the cached copy.
         """
         cast(PeerManager, self.peer_manager).load_peers(force_download=force_download)
+        self._sync_peer_install_sources_to_job_client()
 
     def _check_peer_request_exists(self, email: str) -> bool:
         """Check if a peer request exists. Delegates to PeerManager."""
@@ -1004,6 +1009,7 @@ class SyftboxManager(BaseModel):
         self.peer_manager.approve_peer_request(
             email_or_peer, verbose=verbose, peer_must_exist=peer_must_exist
         )
+        self._sync_peer_install_sources_to_job_client()
         self._post_approve_peer_do(email_or_peer)
 
     def _post_approve_peer_do(self, email_or_peer: str | Peer):
@@ -1015,6 +1021,20 @@ class SyftboxManager(BaseModel):
         if self.has_do_role:
             self.job_client.setup_ds_job_folder_as_do(peer_email)
             self._share_any_datasets_with_peer(peer_email)
+
+    def _sync_peer_install_sources_to_job_client(self) -> None:
+        """Copy each peer's advertised syft-client install source into job_client.
+
+        Called after peer version exchanges so that, when the DS submits a job
+        to a DO, the run.sh references the DO's local install path rather than
+        the DS's local detection.
+        """
+        if not self.job_client:
+            return
+        for peer in self.peer_manager.peer_store.syncable_peers:
+            source = peer.version.syft_client_install_source if peer.version else None
+            if source:
+                self.job_client.peer_install_sources[peer.email] = source
 
     def _ensure_local_peer_permissions(self) -> None:
         """Recreate local permission files for all approved peers.

--- a/syft_client/sync/version/version_info.py
+++ b/syft_client/sync/version/version_info.py
@@ -4,6 +4,7 @@ VersionInfo model for representing version information.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
@@ -42,6 +43,7 @@ class VersionInfo(BaseModel):
     min_supported_syft_client_version: str
     protocol_version: str
     min_supported_protocol_version: str
+    syft_client_install_source: Optional[str] = None
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def compatibility_status_with(
@@ -100,11 +102,21 @@ class VersionInfo(BaseModel):
     @classmethod
     def current(cls) -> "VersionInfo":
         """Create VersionInfo with current version constants."""
+        install_source: Optional[str] = None
+        try:
+            from syft_job.install_source import get_syft_client_install_source
+
+            install_source = get_syft_client_install_source()
+        except Exception as e:
+            logger = logging.getLogger(__name__)
+            logger.debug(f"Could not detect syft-client install source: {e}")
+
         return cls(
             syft_client_version=SYFT_CLIENT_VERSION,
             min_supported_syft_client_version=MIN_SUPPORTED_SYFT_CLIENT_VERSION,
             protocol_version=PROTOCOL_VERSION,
             min_supported_protocol_version=MIN_SUPPORTED_PROTOCOL_VERSION,
+            syft_client_install_source=install_source,
         )
 
     def to_json(self) -> str:

--- a/tests/unit/test_install_source_advertise.py
+++ b/tests/unit/test_install_source_advertise.py
@@ -1,0 +1,135 @@
+"""Tests for DO advertising syft-client install source via VersionInfo.
+
+Covers:
+- VersionInfo carries the new field and round-trips through JSON
+- Backward compat: JSON missing the new field parses with field=None
+- End-to-end: after pair setup, DS's JobClient knows DO's install source
+- submit_python_job bakes the DO's source into run.sh
+- Fallback path: DS warns and falls back to local detection when DO did not advertise
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from syft_client.sync.syftbox_manager import SyftboxManager
+from syft_client.sync.version.version_info import VersionInfo
+
+
+@pytest.fixture(autouse=True)
+def _clear_install_source_cache():
+    """get_syft_client_install_source uses lru_cache; clear so env-var patches work."""
+    from syft_job.install_source import get_syft_client_install_source
+
+    get_syft_client_install_source.cache_clear()
+    yield
+    get_syft_client_install_source.cache_clear()
+
+
+class TestVersionInfoCarriesInstallSource:
+    def test_current_populates_install_source(self):
+        v = VersionInfo.current()
+        assert v.syft_client_install_source is not None
+        assert isinstance(v.syft_client_install_source, str)
+        assert len(v.syft_client_install_source) > 0
+
+    def test_current_uses_env_var_override(self, monkeypatch):
+        monkeypatch.setenv("SYFT_CLIENT_INSTALL_SOURCE", "/do/local/path")
+        # cache cleared by fixture
+        v = VersionInfo.current()
+        assert v.syft_client_install_source == "/do/local/path"
+
+    def test_json_roundtrip_preserves_install_source(self, monkeypatch):
+        monkeypatch.setenv("SYFT_CLIENT_INSTALL_SOURCE", "/do/local/path")
+        v = VersionInfo.current()
+        restored = VersionInfo.from_json(v.to_json())
+        assert restored.syft_client_install_source == "/do/local/path"
+
+    def test_missing_field_parses_as_none_backward_compat(self):
+        # Simulate JSON written by an older client (no install_source key)
+        base = VersionInfo.current()
+        payload = json.loads(base.to_json())
+        payload.pop("syft_client_install_source", None)
+        legacy_json = json.dumps(payload)
+
+        restored = VersionInfo.from_json(legacy_json)
+        assert restored.syft_client_install_source is None
+        assert restored.syft_client_version == base.syft_client_version
+
+
+class TestEndToEndPeerInstallSourcePropagation:
+    def test_ds_job_client_learns_do_install_source(self, monkeypatch):
+        monkeypatch.setenv("SYFT_CLIENT_INSTALL_SOURCE", "/do/local/syft-client")
+
+        ds, do = SyftboxManager.pair_with_mock_drive_service_connection()
+
+        assert do.email in ds.job_client.peer_install_sources
+        assert ds.job_client.peer_install_sources[do.email] == "/do/local/syft-client"
+
+    def test_submit_python_job_bakes_do_source_into_run_sh(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SYFT_CLIENT_INSTALL_SOURCE", "/do/local/syft-client")
+
+        ds, do = SyftboxManager.pair_with_mock_drive_service_connection()
+
+        # Minimal job: a single Python file
+        code = tmp_path / "main.py"
+        code.write_text("print('hello')\n")
+
+        job_dir = ds.job_client.submit_python_job(
+            user=do.email, code_path=str(code), job_name="my-test-job"
+        )
+
+        run_sh = (Path(job_dir) / "run.sh").read_text()
+        # The DO's advertised source must appear in the uv pip install line,
+        # and the DS's local source must NOT be substituted instead.
+        assert "/do/local/syft-client" in run_sh
+        assert "uv pip install" in run_sh
+
+
+class TestFallbackWhenDoDidNotAdvertise:
+    def test_falls_back_and_warns_when_peer_has_no_source(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SYFT_CLIENT_INSTALL_SOURCE", "/ds/local/syft-client")
+
+        ds, do = SyftboxManager.pair_with_mock_drive_service_connection()
+
+        # Simulate an older DO: clear the advertised source from DS's JobClient.
+        ds.job_client.peer_install_sources.pop(do.email, None)
+
+        code = tmp_path / "main.py"
+        code.write_text("print('hello')\n")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            job_dir = ds.job_client.submit_python_job(
+                user=do.email,
+                code_path=str(code),
+                job_name="fallback-job",
+            )
+
+        # A prominent warning must have been emitted.
+        messages = [str(w.message) for w in caught]
+        assert any("No syft-client install source advertised" in m for m in messages), (
+            f"Expected fallback warning, got: {messages}"
+        )
+
+        # The DS's local detection result should be used as the fallback.
+        run_sh = (Path(job_dir) / "run.sh").read_text()
+        assert "/ds/local/syft-client" in run_sh
+
+
+class TestVersionInfoCurrentNeverRaises:
+    def test_current_returns_versioninfo_even_if_detection_fails(self):
+        # Force the install-source helper to blow up; current() must still return
+        # a usable VersionInfo with install_source=None.
+        with patch(
+            "syft_job.install_source.get_syft_client_install_source",
+            side_effect=RuntimeError("boom"),
+        ):
+            v = VersionInfo.current()
+        assert isinstance(v, VersionInfo)
+        assert v.syft_client_install_source is None


### PR DESCRIPTION
## Summary

- Add `syft_client_install_source` field to `VersionInfo`, populated via the existing `get_syft_client_install_source()` helper. Pydantic Optional with `None` default keeps backward compat with older peer JSON.
- `JobClient` now holds a `peer_install_sources: dict[str, str]` (DO email → install source). `submit_python_job` reads from it when generating `run.sh` so the install line points at the DO's local path rather than whatever the DS happened to have installed.
- `SyftboxManager._sync_peer_install_sources_to_job_client()` plumbs each peer's advertised source into `JobClient` after `add_peer`, `approve_peer_request`, and `load_peers`. The mock-drive pair helper now does a final `ds.load_peers()` so DS sees DO's accepted state and version right after pairing.
- Fallback: if a peer's `VersionInfo` lacks the field (older client), `submit_python_job` emits a prominent `warnings.warn` and falls back to local detection. Bash jobs are unchanged — they're still passed through verbatim.

## Test plan

- [x] `just test-unit-fast` — 401 passed (incl. 8 new tests covering field round-trip, backward-compat parsing, end-to-end peer propagation, run.sh contents, and the fallback-warning path)
- [x] `pre-commit run --all-files` — clean
- [ ] Sanity-check by pairing a DS + DO and inspecting the generated `run.sh` in a real notebook