### PR TITLE
fix: use correct nonces field in TEE token request

### DIFF
--- a/packages/syft-enclave/src/syft_enclaves/tee_token.py
+++ b/packages/syft-enclave/src/syft_enclaves/tee_token.py
@@ -80,8 +80,8 @@ def fetch_attestation_token(eat_nonce: list[str] | None = None) -> str:
         "audience": TOKEN_AUDIENCE,
         "token_type": "OIDC",
     }
-    # if eat_nonce:
-    #     payload["eat_nonce"] = eat_nonce
+    if eat_nonce:
+        payload["nonces"] = eat_nonce
     body = json.dumps(payload)
     conn.request(
         "POST",


### PR DESCRIPTION
Two fixes for TEE attestation token requests:

1. Use `nonces` field (not `eat_nonce`) in the `/v1/token` request body — was causing 400 errors on enclave startup
2. Use plain version string in nonce slot instead of sha256 hash — human-readable in the JWT and simpler verification