### PR TITLE
fix: SA propagation delay and add enclave optional dependency

### DIFF
--- a/packages/syft-enclave/Justfile
+++ b/packages/syft-enclave/Justfile
@@ -285,10 +285,13 @@ provision-secret-sa token_path secret=secret_name_default sa=sa_name_default: _p
       --data-file="{{token_path}}" --project="$project_id"
 
     sa_full="{{sa}}@${project_id}.iam.gserviceaccount.com"
-    gcloud iam service-accounts describe "$sa_full" --project="$project_id" >/dev/null 2>&1 || \
+    if ! gcloud iam service-accounts describe "$sa_full" --project="$project_id" >/dev/null 2>&1; then
       gcloud iam service-accounts create {{sa}} \
         --display-name="Syft enclave service account" \
         --project="$project_id"
+      echo "Waiting for SA to propagate..."
+      sleep 10
+    fi
 
     gcloud secrets add-iam-policy-binding {{secret}} \
       --role=roles/secretmanager.secretAccessor \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,8 @@ datasets = [
 job = [
     "syft-job==0.1.39",
 ]
-enclave = [
-    "syft-enclave==0.1.0",
-]
 all = [
-    "syft-client[datasets,job,enclave]",
+    "syft-client[datasets,job]",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,11 @@ datasets = [
 job = [
     "syft-job==0.1.39",
 ]
+enclave = [
+    "syft-enclave==0.1.0",
+]
 all = [
-    "syft-client[datasets,job]",
+    "syft-client[datasets,job,enclave]",
 ]
 
 [tool.uv]

--- a/syft_client/sync/connections/drive/gdrive_retry.py
+++ b/syft_client/sync/connections/drive/gdrive_retry.py
@@ -10,6 +10,7 @@ from typing import Any, TypeVar
 
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload
+from httplib2 import RedirectMissingLocation
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,8 @@ RETRYABLE_REASONS = {
 # Socket/TLS transients raised by httplib2 when Google closes an idle keepalive
 # connection. googleapiclient's own retry loop only catches ssl.SSLError and
 # socket.timeout, so these escape and surface to callers as unhandled errors.
+# RedirectMissingLocation is a transient GDrive bug during resumable uploads
+# where the server returns a 3xx without a Location header.
 RETRYABLE_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
     ConnectionResetError,
     ConnectionAbortedError,
@@ -39,6 +42,7 @@ RETRYABLE_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
     ssl.SSLError,
     http.client.RemoteDisconnected,
     http.client.BadStatusLine,
+    RedirectMissingLocation,
 )
 
 T = TypeVar("T")

--- a/tests/unit/test_gdrive_retry.py
+++ b/tests/unit/test_gdrive_retry.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from googleapiclient.errors import HttpError
+from httplib2 import RedirectMissingLocation
 
 from syft_client.sync.connections.drive.gdrive_retry import (
     batch_execute_with_retries,
@@ -44,6 +45,7 @@ TRANSPORT_INSTANCES = [
     ssl.SSLError("ssl"),
     http.client.RemoteDisconnected("remote disconnected"),
     http.client.BadStatusLine("bad status"),
+    RedirectMissingLocation("missing location", Mock(), b""),
 ]
 
 


### PR DESCRIPTION
## Summary                                                                             
- Add 10s sleep after service account creation in `provision-secret-sa` Justfile recipe
 to allow GCP IAM propagation before the policy binding (fixes `Service account does 
not exist` error)                                                                      
- Add `syft-enclave` as an optional dependency so it can be installed via `pip install 
"syft-client[enclave]"`                                                                
- Add `RedirectMissingLocation` to retryable transport errors — GDrive occasionally    
returns a 3xx redirect without a `Location` header during resumable uploads (large     
files like dataset event messages), causing an unhandled crash. The existing           
retry/backoff logic now handles it.                                                    
                                                                                       
## Test plan                                                                           
- [ ] Run `just provision-secret-sa` with a fresh SA name and verify no binding error  
- [ ] Run `uv pip install "git+...@swag/enclave-sa-fixes[enclave]"` and verify         
`syft_enclaves` is installed                                                           
- [ ] Verify `share_private_dataset` with large datasets no longer crashes on transient
 redirect errors 