### PR TITLE
refactor: use plain version string in eat_nonce instead of hash

### DIFF
--- a/packages/syft-enclave/docker/attestation_server.py
+++ b/packages/syft-enclave/docker/attestation_server.py
@@ -206,7 +206,7 @@ def attestation(nonce: str | None = None):
             "syft_client_version": version,
             "attestation": structured,
             "nonce_info": {
-                "version_hash": eat_nonce[0],
+                "version": eat_nonce[0],
                 "caller_nonce": nonce,
             },
             "raw_token": raw_token,

--- a/packages/syft-enclave/src/syft_enclaves/tee_token.py
+++ b/packages/syft-enclave/src/syft_enclaves/tee_token.py
@@ -7,7 +7,6 @@ server (``docker/attestation_server.py``) and the enclave runner.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 import socket
@@ -19,25 +18,20 @@ from syft_client.version import SYFT_CLIENT_VERSION
 TEE_SOCKET_PATH = Path("/run/container_launcher/teeserver.sock")
 TOKEN_AUDIENCE = "syft-client-attestation"
 
-_NONCE_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+_NONCE_PATTERN = re.compile(r"^[a-zA-Z0-9_.-]+$")
 _NONCE_MAX_LEN = 74
 
 
 # -- eat_nonce helpers --------------------------------------------------------
 
 
-def version_hash() -> str:
-    """SHA-256 hex digest of the syft-client version string."""
-    return hashlib.sha256(SYFT_CLIENT_VERSION.encode()).hexdigest()
-
-
 def build_eat_nonce(caller_nonce: str | None = None) -> list[str]:
-    """Build the eat_nonce array for the attestation token request.
+    """Build the nonces array for the attestation token request.
 
-    Slot 0: SHA-256 of syft-client version.
+    Slot 0: plain syft-client version string (e.g. "0.1.117").
     Slot 1: caller-supplied freshness nonce (if provided).
     """
-    nonces = [version_hash()]
+    nonces = [SYFT_CLIENT_VERSION]
     if caller_nonce:
         nonces.append(caller_nonce)
     return nonces

--- a/syft_client/sync/version/attestation.py
+++ b/syft_client/sync/version/attestation.py
@@ -8,7 +8,6 @@ the claims inside it to ensure the enclave is trustworthy.
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass, field
 
 from google.auth.transport import requests as google_requests
@@ -66,10 +65,6 @@ class AttestationResult:
             else:
                 icon = "  ❌"
             print(f"{icon} {check.label:<20s} — {check.detail}")
-
-
-def _expected_version_hash() -> str:
-    return hashlib.sha256(EXPECTED_SYFT_VERSION.encode()).hexdigest()
 
 
 def verify_attestation_token(token: str, verbose: bool = True) -> AttestationResult:
@@ -149,20 +144,22 @@ def verify_attestation_token(token: str, verbose: bool = True) -> AttestationRes
             print("❌ Attestation failed — enclave is NOT trusted")
         raise AttestationError(f"Debug mode detected: dbgstat={dbgstat!r}", result)
 
-    # 4. Version hash
+    # 4. Version match
     if verbose:
         print("  ⏳ Version match ...")
     eat_nonce = claims.get("eat_nonce", [])
-    expected_hash = _expected_version_hash()
-    actual_hash = eat_nonce[0] if eat_nonce else None
-    if not actual_hash:
+    # Google returns a string for single nonce, array for multiple
+    if isinstance(eat_nonce, str):
+        eat_nonce = [eat_nonce]
+    actual_version = eat_nonce[0] if eat_nonce else None
+    if not actual_version:
         result.add(
             "version_match",
             "Version match",
             None,
-            "no version hash in token",
+            "no version in token",
         )
-    elif actual_hash == expected_hash:
+    elif actual_version == EXPECTED_SYFT_VERSION:
         result.add(
             "version_match",
             "Version match",
@@ -174,12 +171,12 @@ def verify_attestation_token(token: str, verbose: bool = True) -> AttestationRes
             "version_match",
             "Version match",
             False,
-            f"version hash mismatch (expected sha256 of {EXPECTED_SYFT_VERSION!r})",
+            f"version mismatch (enclave={actual_version}, expected={EXPECTED_SYFT_VERSION})",
         )
         if verbose:
             result.print_checklist()
             print("❌ Attestation failed — enclave is NOT trusted")
-        raise AttestationError("Version hash mismatch", result)
+        raise AttestationError("Version mismatch", result)
 
     # 5. Image digest
     if verbose:

--- a/tests/unit/test_attestation.py
+++ b/tests/unit/test_attestation.py
@@ -1,6 +1,5 @@
 """Tests for enclave attestation verification."""
 
-import hashlib
 from unittest.mock import patch
 
 import pytest
@@ -12,7 +11,6 @@ from syft_client.sync.version.attestation import (
     verify_attestation_token,
 )
 
-VALID_VERSION_HASH = hashlib.sha256(EXPECTED_SYFT_VERSION.encode()).hexdigest()
 FAKE_IMAGE_DIGEST = "sha256:abc123"
 
 
@@ -21,7 +19,7 @@ def _valid_claims(**overrides):
     claims = {
         "secboot": True,
         "dbgstat": "disabled-since-boot",
-        "eat_nonce": [VALID_VERSION_HASH],
+        "eat_nonce": [EXPECTED_SYFT_VERSION],
         "submods": {
             "container": {
                 "image_digest": FAKE_IMAGE_DIGEST,
@@ -45,7 +43,7 @@ def mock_verify():
 
 
 class TestVerifyAttestationToken:
-    @pytest.mark.skip(reason="version hash check is currently disabled")
+    @pytest.mark.skip(reason="version check is currently disabled")
     def test_all_checks_pass(self, mock_verify):
         result = verify_attestation_token("fake-token", verbose=False)
         assert result.all_passed()
@@ -74,16 +72,23 @@ class TestVerifyAttestationToken:
         with pytest.raises(AttestationError, match="Debug mode"):
             verify_attestation_token("fake-token", verbose=False)
 
-    def test_version_hash_mismatch(self, mock_verify):
-        mock_verify.return_value = _valid_claims(eat_nonce=["wrong-hash"])
-        with pytest.raises(AttestationError, match="Version hash"):
+    def test_version_mismatch(self, mock_verify):
+        mock_verify.return_value = _valid_claims(eat_nonce=["0.0.1"])
+        with pytest.raises(AttestationError, match="Version mismatch"):
             verify_attestation_token("fake-token", verbose=False)
 
-    @pytest.mark.skip(reason="version hash check is currently disabled")
-    def test_version_hash_missing(self, mock_verify):
+    @pytest.mark.skip(reason="version check is currently disabled")
+    def test_version_missing(self, mock_verify):
         mock_verify.return_value = _valid_claims(eat_nonce=[])
-        with pytest.raises(AttestationError, match="Version hash"):
+        with pytest.raises(AttestationError, match="Version mismatch"):
             verify_attestation_token("fake-token", verbose=False)
+
+    def test_version_as_string(self, mock_verify):
+        """Google returns eat_nonce as a string for single nonce."""
+        mock_verify.return_value = _valid_claims(eat_nonce=EXPECTED_SYFT_VERSION)
+        result = verify_attestation_token("fake-token", verbose=False)
+        version_check = next(c for c in result.checks if c.name == "version_match")
+        assert version_check.passed is not False
 
     def test_image_digest_mismatch(self, mock_verify):
         with patch(
@@ -94,7 +99,7 @@ class TestVerifyAttestationToken:
             with pytest.raises(AttestationError, match="Image digest"):
                 verify_attestation_token("fake-token", verbose=False)
 
-    @pytest.mark.skip(reason="version hash check is currently disabled")
+    @pytest.mark.skip(reason="version check is currently disabled")
     def test_image_digest_skipped_when_not_configured(self, mock_verify):
         """When EXPECTED_IMAGE_DIGEST is empty, image check passes with skip note."""
         result = verify_attestation_token("fake-token", verbose=False)


### PR DESCRIPTION
Use the plain syft-client version string (e.g. "0.1.117") in the attestation nonce instead of sha256 hashing it. The value is still signed inside the Google JWT — hashing added no security benefit but made it unreadable. Also handles Google returning eat_nonce as a string (single nonce) instead of an array.