### PR TITLE
docs: split collaboration flow into its own doc

### DIFF
--- a/packages/syft-enclave/README.md
+++ b/packages/syft-enclave/README.md
@@ -4,6 +4,7 @@ Enclave support for syft-client, enabling secure computation in Trusted Executio
 
 ## About
 
+- [Collaboration Flow](./docs/flow.md)
 - [Security Overview](./docs/security.md)
 - [Enclave Architecture](./docs/enclave_architecture.md)
 - [API](./docs/api.md)

--- a/packages/syft-enclave/docs/flow.md
+++ b/packages/syft-enclave/docs/flow.md
@@ -1,0 +1,89 @@
+# The Collaboration Flow
+
+This document walks through an end-to-end private collaboration in `syft-enclave`, step by step. It
+is the best place to start — the [Security Overview](./security.md) builds directly on this flow and
+assumes you have read it first.
+
+Users connect via **Jupyter or Google Colab** and sync through **Google Drive**. Using this as a
+communication platform, several parties can compute on each other's data. Backed by **confidential
+compute**, a **secure enclave** running an **open-source docker container with syft-client** runs
+computations from those parties **without any of them having to reveal that data**.
+
+> **Where we are.** This is an early **alpha** release — a deliberate zero-to-one effort. The goal
+> right now is not scale; it is to push the _Overton window_ of what private collaboration is allowed
+> to look like: to demonstrate that two organizations and an outside analyst really can run a joint
+> computation where nobody hands over their secrets. Everything is built around that
+> **mutual-secrecy** guarantee.
+
+---
+
+## The parties
+
+Throughout the story there are three parties:
+
+- **DO1** — a data owner who holds a private **benchmark** (for example, loaded in Google Colab).
+- **DO2** — a data owner who holds a private **model and its inference code** (also, say, in Colab).
+- **DS** — a data scientist who writes the **analysis** that brings the two together.
+
+In the middle sits a **secure enclave**: a sealed, confidential-compute environment that nobody
+logs into and that runs a known, open-source docker container.
+
+## Step 0 — Everyone installs PySyft
+
+All parties install the same open-source client (PySyft). DO1 brings a private benchmark, DO2
+brings a private model and inference code, and the DS will bring the analysis. The secure enclave
+is the neutral ground where the computation will eventually happen — none of the three parties
+controls it.
+
+<img src="assets/security/step0.png" width="600" alt="Step 0: all parties install pysyft">
+
+## Step 1 — Data owners upload their data
+
+Each data owner uploads their private asset toward the enclave (the bytes travel through Google
+Drive). The data is only ever used inside the enclave: **it never leaks to the other parties, it is
+removed after the computation, and an owner can delete it at any time.**
+
+<img src="assets/security/step1.png" width="600" alt="Step 1: data owners upload data">
+
+## Step 2 — The data scientist uploads a private-private analysis
+
+The DS writes the analysis — the code that loads the benchmark, runs it against the model, and
+scores the result — and uploads it. The enclave forwards this code to **both** data owners so they
+can see exactly what is being proposed against their data before anything runs.
+
+<img src="assets/security/step2.png" width="600" alt="Step 2: upload private-private analysis">
+
+The analysis is just ordinary code. In pseudocode it reads the benchmark, runs the model's
+inference on it, and reports a score:
+
+<img src="assets/security/step2a.png" width="600" alt="Step 2: analysis pseudocode">
+
+## Step 3 — Data owners approve the analysis
+
+Because this analysis touches data from two different owners, it only runs once **both** owners
+have approved it. Either owner can decline. Nobody — not the DS, not the other owner, not the
+operators of the enclave — can force a computation to run over data without that data owner's
+explicit consent.
+
+<img src="assets/security/step3.png" width="600" alt="Step 3: data owners approve the analysis">
+
+## Step 4 — The enclave executes the analysis
+
+With both approvals in hand, the enclave runs the analysis inside its open-source docker container
+on confidential-compute hardware. The two private inputs meet only here, inside the sealed
+environment — never on anyone's laptop and never in plaintext on Google Drive.
+
+<img src="assets/security/step4.png" width="600" alt="Step 4: analysis is executed in the enclave">
+
+## Step 5 — The result is shared with the DS
+
+Only the agreed-upon output leaves the enclave and is delivered to the DS. The private benchmark
+and the private model stay where they started. Everyone got something — a result — and nobody had
+to give up their secret to get it.
+
+<img src="assets/security/step5.png" width="600" alt="Step 5: result is shared with the data scientist">
+
+---
+
+Next, read the [Security Overview](./security.md) to understand how each of these steps is made
+secure.

--- a/packages/syft-enclave/docs/security.md
+++ b/packages/syft-enclave/docs/security.md
@@ -1,92 +1,13 @@
 # Security Overview
 
-This document provides a concise, accessible overview of how private collaboration works on in `syft-enclave` and the principles that make it secure. It is meant for a broad audience: you do not need to
-know the internals to follow along. Users connect via **Jupyter or Google Colab** and sync through **Google Drive**. Using this as communication platofrm,
-several parties can compute on each other's data. Backed by **confidential compute**, a **secure
-enclave** running an **open-source docker container with syft-client** runs computations from those parties **without any of them having to reveal that
-data**.
+> **Read this first:** This document assumes you understand the
+> [Collaboration Flow](./flow.md). That document explains _what_ happens end to end —
+> the data owners, the data scientist, the enclave, and the Steps 0–5 referenced below. This
+> document explains _how_ each of those steps is made secure.
 
-> **Where we are.** This is an early **alpha** release — a deliberate zero-to-one effort. The goal
-> right now is not scale; it is to push the _Overton window_ of what private collaboration is allowed
-> to look like: to demonstrate that two organizations and an outside analyst really can run a joint
-> computation where nobody hands over their secrets. Everything below is built around that
-> **mutual-secrecy** guarantee.
+The collaboration flow rests on a few security building blocks. Here is what makes it trustworthy.
 
----
-
-## Part A — The collaboration, end to end
-
-Throughout the story there are three parties:
-
-- **DO1** — a data owner who holds a private **benchmark** (for example, loaded in Google Colab).
-- **DO2** — a data owner who holds a private **model and its inference code** (also, say, in Colab).
-- **DS** — a data scientist who writes the **analysis** that brings the two together.
-
-In the middle sits a **secure enclave**: a sealed, confidential-compute environment that nobody
-logs into and that runs a known, open-source docker container.
-
-### Step 0 — Everyone installs PySyft
-
-All parties install the same open-source client (PySyft). DO1 brings a private benchmark, DO2
-brings a private model and inference code, and the DS will bring the analysis. The secure enclave
-is the neutral ground where the computation will eventually happen — none of the three parties
-controls it.
-
-<img src="assets/security/step0.png" width="600" alt="Step 0: all parties install pysyft">
-
-### Step 1 — Data owners upload their data
-
-Each data owner uploads their private asset toward the enclave (the bytes travel through Google
-Drive). The data is only ever used inside the enclave: **it never leaks to the other parties, it is
-removed after the computation, and an owner can delete it at any time.**
-
-<img src="assets/security/step1.png" width="600" alt="Step 1: data owners upload data">
-
-### Step 2 — The data scientist uploads a private-private analysis
-
-The DS writes the analysis — the code that loads the benchmark, runs it against the model, and
-scores the result — and uploads it. The enclave forwards this code to **both** data owners so they
-can see exactly what is being proposed against their data before anything runs.
-
-<img src="assets/security/step2.png" width="600" alt="Step 2: upload private-private analysis">
-
-The analysis is just ordinary code. In pseudocode it reads the benchmark, runs the model's
-inference on it, and reports a score:
-
-<img src="assets/security/step2a.png" width="600" alt="Step 2: analysis pseudocode">
-
-### Step 3 — Data owners approve the analysis
-
-Because this analysis touches data from two different owners, it only runs once **both** owners
-have approved it. Either owner can decline. Nobody — not the DS, not the other owner, not the
-operators of the enclave — can force a computation to run over data without that data owner's
-explicit consent.
-
-<img src="assets/security/step3.png" width="600" alt="Step 3: data owners approve the analysis">
-
-### Step 4 — The enclave executes the analysis
-
-With both approvals in hand, the enclave runs the analysis inside its open-source docker container
-on confidential-compute hardware. The two private inputs meet only here, inside the sealed
-environment — never on anyone's laptop and never in plaintext on Google Drive.
-
-<img src="assets/security/step4.png" width="600" alt="Step 4: analysis is executed in the enclave">
-
-### Step 5 — The result is shared with the DS
-
-Only the agreed-upon output leaves the enclave and is delivered to the DS. The private benchmark
-and the private model stay where they started. Everyone got something — a result — and nobody had
-to give up their secret to get it.
-
-<img src="assets/security/step5.png" width="600" alt="Step 5: result is shared with the data scientist">
-
----
-
-## Part B — How the security works
-
-Part A describes the flow. The following section describes how we make this secure
-
-### 1. SyftBox and permissions
+## 1. SyftBox and permissions
 
 The basic unit is a **SyftBox**: a local folder of files. Every file carries **read and write
 permissions for each peer**, which decide who is allowed to see or change it. `syft-client`
@@ -101,7 +22,7 @@ peers over Google Drive** — only the files a peer is allowed to read are ever 
 See the [permissions guide](../../syft-permissions/docs/permission-user-docs.md) for the full
 syntax.
 
-### 2. Peer-to-peer file sharing
+## 2. Peer-to-peer file sharing
 
 Communication between parties is **transport-agnostic** — it works over any mechanism that can
 deliver a file. Today that transport is **Google Drive**. `syft-client` makes "requests" simply by
@@ -111,14 +32,14 @@ servers, just shared files.
 
 See the [Google Drive connection doc](../../../docs/connections.md) for the folder layout and request flow.
 
-### 3. All files are encrypted and signed
+## 3. All files are encrypted and signed
 
 Every file `syft-client` exchanges is **encrypted and signed**. The signature lets the recipient
 **cryptographically prove who** produced a file. Encryption means that even if a file is accidentally shared with the wrong person, it is
 **unreadable** to them. The shared Google Drive folder is just a delivery mechanism; the security
 does not depend on Google Drive keeping anything secret.
 
-### 4. Attestation bootstraps the encryption handshake
+## 4. Attestation bootstraps the encryption handshake
 
 Encryption and signing only help if you know whose keys to trust. For a **person**, this is relatively trivial:
 if a real human controls a Google Drive account, `syft-client` can reasonably assume that what comes
@@ -150,7 +71,8 @@ properties are enforced end to end by the layers above it — **encryption** pro
 adversary at most cause a denial of service; it never yields access to plaintext or the ability to
 forge an accepted message.
 
-This is what lets Steps 1–5 happen without anyone trusting Google Drive, the network, or each other.
+This is what lets Steps 1–5 of the [Collaboration Flow](./flow.md) happen without
+anyone trusting Google Drive, the network, or each other.
 
 For the enclave deployment details, see the
 [enclave architecture doc](./enclave_architecture.md).

--- a/packages/syft-enclave/docs/security.md
+++ b/packages/syft-enclave/docs/security.md
@@ -1,11 +1,17 @@
 # Security Overview
 
 > **Read this first:** This document assumes you understand the
-> [Collaboration Flow](./flow.md). That document explains _what_ happens end to end —
-> the data owners, the data scientist, the enclave, and the Steps 0–5 referenced below. This
+> [Enclave Flow](./flow.md). That document describes the parties involved and _what_ happens end to end —
+> the data owners, the data scientist, the enclave, and how the analysis is submitted and executed. This
 > document explains _how_ each of those steps is made secure.
 
-The collaboration flow rests on a few security building blocks. Here is what makes it trustworthy.
+> This is an early **alpha** release — a deliberate zero-to-one effort. The goal
+> right now is not scale; it is to push the _Overton window_ of what private collaboration is allowed
+> to look like: to demonstrate that two organizations and an outside analyst really can run a joint
+> computation where nobody hands over their secrets. Everything is built around that
+> **mutual-secrecy** guarantee.
+
+The flow rests on a few security building blocks. This document describes what makes it trustworthy.
 
 ## 1. SyftBox and permissions
 
@@ -39,7 +45,23 @@ Every file `syft-client` exchanges is **encrypted and signed**. The signature le
 **unreadable** to them. The shared Google Drive folder is just a delivery mechanism; the security
 does not depend on Google Drive keeping anything secret.
 
-## 4. Attestation bootstraps the encryption handshake
+## 4. The enclave runs in a Trusted Execution Environment
+
+The computation itself runs inside a **secure enclave**: a **docker container with `syft-client`**
+executing in a **Trusted Execution Environment (TEE)** on confidential-compute hardware. The TEE
+isolates the running code and encrypts its memory, so the workload is **not controlled or observable
+by any person** — not the cloud operator, not the data owners, and not the data scientist. Nobody
+can log into it, read its memory, or change what it does.
+
+Inside this environment the enclave enforces the core consent rule: it **only runs computations that
+every data owner has approved**. An analysis that touches two owners' data does not execute until
+**both** have signed off (see Step 3 of the [Enclave Flow](./flow.md)). The result is a neutral
+party that no human steers, yet that runs only what all data owners agreed to.
+
+For how the enclave is built and deployed, see the
+[enclave architecture doc](./enclave_architecture.md).
+
+## 5. Attestation bootstraps the encryption handshake
 
 Encryption and signing only help if you know whose keys to trust. For a **person**, this is relatively trivial:
 if a real human controls a Google Drive account, `syft-client` can reasonably assume that what comes
@@ -71,8 +93,5 @@ properties are enforced end to end by the layers above it — **encryption** pro
 adversary at most cause a denial of service; it never yields access to plaintext or the ability to
 forge an accepted message.
 
-This is what lets Steps 1–5 of the [Collaboration Flow](./flow.md) happen without
+This is what lets Steps 1–5 of the [Enclave Flow](./flow.md) happen without
 anyone trusting Google Drive, the network, or each other.
-
-For the enclave deployment details, see the
-[enclave architecture doc](./enclave_architecture.md).

--- a/packages/syft-enclave/docs/security.md
+++ b/packages/syft-enclave/docs/security.md
@@ -58,6 +58,13 @@ every data owner has approved**. An analysis that touches two owners' data does 
 **both** have signed off (see Step 3 of the [Enclave Flow](./flow.md)). The result is a neutral
 party that no human steers, yet that runs only what all data owners agreed to.
 
+Note that the security guarantees above cover **where** the code runs and **who** can see it — they
+do not vouch for **what the code does**. Responsibility for the safety of the analysis itself lies
+with **both data owners**: each must **read the submitted code carefully** before approving it and
+satisfy themselves that it does nothing with their data that they have not allowed. Approval is a
+deliberate review step, not a rubber stamp — the enclave will run exactly what both owners signed
+off on, and nothing more.
+
 For how the enclave is built and deployed, see the
 [enclave architecture doc](./enclave_architecture.md).
 

--- a/packages/syft-enclave/docs/security.md
+++ b/packages/syft-enclave/docs/security.md
@@ -58,11 +58,11 @@ every data owner has approved**. An analysis that touches two owners' data does 
 **both** have signed off (see Step 3 of the [Enclave Flow](./flow.md)). The result is a neutral
 party that no human steers, yet that runs only what all data owners agreed to.
 
-Note that the security guarantees above cover **where** the code runs and **who** can see it — they
-do not vouch for **what the code does**. Responsibility for the safety of the analysis itself lies
+Note that the security guarantees above cover **where** the code runs and **what data it can
+access** — they do not vouch for **what the code does**. Responsibility for the safety of the analysis itself lies
 with **both data owners**: each must **read the submitted code carefully** before approving it and
-satisfy themselves that it does nothing with their data that they have not allowed. Approval is a
-deliberate review step, not a rubber stamp — the enclave will run exactly what both owners signed
+satisfy themselves that it uses the data only for the agreed-upon purpose. Approval is a
+deliberate review step, not a formality — the enclave will run exactly what both owners signed
 off on, and nothing more.
 
 For how the enclave is built and deployed, see the


### PR DESCRIPTION
## Summary
- Move the end-to-end walkthrough (the parties + Steps 0–5, with the step images) out of `security.md` into a new `packages/syft-enclave/docs/flow.md`.
- `security.md` now opens with a "read this first" pointer to the flow doc and focuses purely on the four security building blocks (permissions, peer-to-peer file sharing, encryption/signing, attestation + threat model).
- The two docs cross-link each other, and both are listed in the enclave README's "About" section.

## Test plan
- [ ] Render `flow.md` and `security.md` on GitHub; confirm the step images load in `flow.md` and the cross-links between the two docs work.
- [ ] Confirm the README links to both docs resolve.