### PR TITLE
fix: propagate dataset deletion from DO to DS via Drive

### DIFF
--- a/syft_client/sync/connections/connection_router.py
+++ b/syft_client/sync/connections/connection_router.py
@@ -305,6 +305,14 @@ class ConnectionRouter(BaseModel):
         connection = self.connection_for_send_message()
         return connection.owner_list_all_dataset_collections_with_permissions()
 
+    def owner_delete_dataset_collection(self, tag: str) -> None:
+        connection = self.connection_for_send_message()
+        connection.owner_delete_dataset_collection(tag)
+
+    def owner_delete_private_dataset_collection(self, tag: str) -> None:
+        connection = self.connection_for_send_message()
+        connection.owner_delete_private_dataset_collection(tag)
+
     def watcher_list_dataset_collections(self) -> list[dict]:
         connection = self.connection_for_receive_message()
         return connection.watcher_list_dataset_collections()

--- a/syft_client/sync/connections/drive/gdrive_transport.py
+++ b/syft_client/sync/connections/drive/gdrive_transport.py
@@ -1640,6 +1640,15 @@ class GDriveConnection(SyftboxPlatformConnection):
 
         return collections
 
+    def owner_delete_dataset_collection(self, tag: str) -> None:
+        """Delete all public dataset collection folders matching the given tag."""
+        collections = self.owner_list_all_dataset_collections_with_permissions()
+        for c in collections:
+            if c.tag == tag:
+                self.delete_file_by_id(c.folder_id)
+                cache_key = f"{c.tag}_{c.content_hash}"
+                self.dataset_collection_folder_id_cache.pop(cache_key, None)
+
     def watcher_list_dataset_collections(self) -> list[dict]:
         """List collections shared with DS (not owned by me).
 
@@ -1801,6 +1810,15 @@ class GDriveConnection(SyftboxPlatformConnection):
             except ValueError:
                 continue
         return collections
+
+    def owner_delete_private_dataset_collection(self, tag: str) -> None:
+        """Delete all private dataset collection folders matching the given tag."""
+        collections = self.owner_list_private_dataset_collections()
+        for c in collections:
+            if c.tag == tag:
+                self.delete_file_by_id(c.folder_id)
+                cache_key = f"private_{c.tag}_{c.content_hash}"
+                self.dataset_collection_folder_id_cache.pop(cache_key, None)
 
     def owner_get_private_collection_file_metadatas(
         self, tag: str, content_hash: str, owner_email: str

--- a/syft_client/sync/syftbox_manager.py
+++ b/syft_client/sync/syftbox_manager.py
@@ -1381,6 +1381,19 @@ class SyftboxManager(BaseModel):
             datasite=datasite,
             require_confirmation=require_confirmation,
         )
+        # Delete collection folders from Google Drive so DS peers
+        # pick up the deletion on their next sync.
+        try:
+            self._connection_router.owner_delete_dataset_collection(name)
+        except Exception:
+            logger.warning("Failed to delete dataset collection '%s' from Drive", name)
+        try:
+            self._connection_router.owner_delete_private_dataset_collection(name)
+        except Exception:
+            logger.warning(
+                "Failed to delete private dataset collection '%s' from Drive",
+                name,
+            )
         if sync:
             self.sync()
 

--- a/tests/unit/test_sync_manager.py
+++ b/tests/unit/test_sync_manager.py
@@ -2040,3 +2040,41 @@ def test_permission_change_triggers_resend():
     assert any("data.txt" in p for p in paths_for_b_after), (
         "Peer B should receive data.txt after permission change"
     )
+
+
+def test_dataset_delete_propagates_to_ds():
+    """Test that deleting a dataset on DO removes it from Drive and DS."""
+    ds_manager, do_manager = SyftboxManager.pair_with_mock_drive_service_connection(
+        use_in_memory_cache=False
+    )
+
+    mock_dset_path, private_dset_path, readme_path = create_tmp_dataset_files()
+
+    # DO creates dataset shared with DS
+    do_manager.create_dataset(
+        name="deleteme",
+        mock_path=mock_dset_path,
+        private_path=private_dset_path,
+        summary="To be deleted",
+        readme_path=readme_path,
+        users=[ds_manager.email],
+    )
+
+    # Verify collection exists on Drive
+    collections = do_manager._connection_router.owner_list_dataset_collections()
+    assert "deleteme" in collections
+
+    # DS syncs and sees the dataset
+    ds_manager.sync()
+    assert len(ds_manager.datasets.get_all()) == 1
+
+    # DO deletes the dataset
+    do_manager.delete_dataset(name="deleteme", require_confirmation=False, sync=True)
+
+    # Verify collection is gone from Drive
+    collections_after = do_manager._connection_router.owner_list_dataset_collections()
+    assert "deleteme" not in collections_after
+
+    # DS syncs again — should pick up the deletion
+    ds_manager.sync()
+    assert len(ds_manager.datasets.get_all()) == 0


### PR DESCRIPTION
## Summary
- When a DO deletes a dataset, also delete the collection folders (public and private) from Google Drive
- The existing DS-side cleanup logic (`_cleanup_stale_dataset_collections()`) then automatically removes the local copy on the next sync
- Previously, `dataset_manager.delete()` only removed local directories, leaving Drive folders intact — DS never detected the deletion

### Changes
- **`gdrive_transport.py`** — add `owner_delete_dataset_collection()` and `owner_delete_private_dataset_collection()` methods
- **`connection_router.py`** — expose both methods via passthrough
- **`syftbox_manager.py`** — call Drive deletion in `delete_dataset()` (best-effort, won't block if Drive fails)
- **`test_sync_manager.py`** — add `test_dataset_delete_propagates_to_ds` end-to-end test

## Test plan
- [x] New test: DO creates dataset, DS syncs (sees it), DO deletes, DS syncs again (dataset gone)
- [x] All 430 unit tests pass