### PR TITLE
fix: return empty list for missing peer outbox instead of raising

### DIFF
--- a/syft_client/sync/connections/drive/gdrive_transport.py
+++ b/syft_client/sync/connections/drive/gdrive_transport.py
@@ -583,7 +583,7 @@ class GDriveConnection(SyftboxPlatformConnection):
     ) -> list[bytes]:
         folder_id = self._get_peer_datasite_outbox_id(peer_email)
         if folder_id is None:
-            raise ValueError(f"Outbox folder for peer {peer_email} not found")
+            return []
 
         file_metadatas = self.get_file_metadatas_from_folder(
             folder_id, since_timestamp=since_timestamp
@@ -621,7 +621,7 @@ class GDriveConnection(SyftboxPlatformConnection):
         """Get file metadata from peer's outbox folder without downloading."""
         folder_id = self._get_peer_datasite_outbox_id(peer_email)
         if folder_id is None:
-            raise ValueError(f"Outbox folder for peer {peer_email} not found")
+            return []
 
         file_metadatas = self.get_file_metadatas_from_folder(
             folder_id, since_timestamp=since_timestamp


### PR DESCRIPTION
## Summary
- When a peer's outbox folder doesn't exist on Drive (e.g. peer in `REQUESTED_BY_ME` state, not yet approved), return `[]` instead of raising `ValueError`
- Affects two methods in `gdrive_transport.py`: `watcher_get_outbox_file_metadatas` and `watcher_get_events_messages`
- Callers already handle empty results gracefully (`sync_down_parallel` returns 0 events)

### Root cause of the flaky test
`test_peer_request_blocks_sync_until_approved` calls `ds_manager.add_peer(DO)` which triggers `sync()`. The sync tries to read the newly added peer's outbox, but it doesn't exist yet (DO hasn't approved). This raised `ValueError` on clean Drive state, but passed when leftover folders from previous runs existed.

## Test plan
- [x] All 430 unit tests pass
- [x] Flaky integration test should now pass consistently on clean Drive state